### PR TITLE
Updating Kubernetes Authprovider, for all services

### DIFF
--- a/plugins/kubernetes-ingestor/src/auth/index.ts
+++ b/plugins/kubernetes-ingestor/src/auth/index.ts
@@ -1,0 +1,1 @@
+export { getAuthCredential } from './kubernetesCredentialProvider';

--- a/plugins/kubernetes-ingestor/src/auth/kubernetesCredentialProvider.ts
+++ b/plugins/kubernetes-ingestor/src/auth/kubernetesCredentialProvider.ts
@@ -1,0 +1,113 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import {
+  AksStrategy,
+  AwsIamStrategy,
+  AzureIdentityStrategy,
+  GoogleServiceAccountStrategy,
+  GoogleStrategy,
+  OidcStrategy,
+  ServiceAccountStrategy,
+} from '@backstage/plugin-kubernetes-backend';
+import { KubernetesCredential } from '@backstage/plugin-kubernetes-node';
+
+export async function getAuthCredential(
+  cluster: any,
+  authProvider: string,
+  config: Config,
+  logger: LoggerService,
+): Promise<KubernetesCredential> {
+  switch (authProvider) {
+    case 'aks': {
+      const aksAuth = new AksStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for AKS authentication',
+        );
+      }
+      const aksAuthConfig = authConfig
+        ?.getOptionalConfig('aks')
+        ?.getOptionalConfig(authEnvironment);
+      if (!aksAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for AKS in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        clientId: aksAuthConfig?.getOptionalString('clientId'),
+        clientSecret: aksAuthConfig?.getOptionalString('clientSecret'),
+        tenantId: aksAuthConfig?.getOptionalString('tenantId'),
+        domainHint: aksAuthConfig?.getOptionalString('domainHint'),
+      };
+      return await aksAuth.getCredential(cluster, requestAuth);
+    }
+    case 'aws': {
+      if (!cluster.authMetadata?.['kubernetes.io/aws-assume-role']) {
+        throw new Error('AWS role ARN not found in cluster auth metadata');
+      }
+      const awsAuth = new AwsIamStrategy({ config });
+      return await awsAuth.getCredential(cluster);
+    }
+    case 'azure': {
+      const azureAuth = new AzureIdentityStrategy(logger);
+      return await azureAuth.getCredential();
+    }
+    case 'google': {
+      const googleAuth = new GoogleStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for Google authentication',
+        );
+      }
+      const googleAuthConfig = authConfig
+        ?.getOptionalConfig('google')
+        ?.getOptionalConfig(authEnvironment);
+      if (!googleAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for Google in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        clientId: googleAuthConfig?.getOptionalString('clientId'),
+        clientSecret: googleAuthConfig?.getOptionalString('clientSecret'),
+      };
+      return await googleAuth.getCredential(cluster, requestAuth);
+    }
+    case 'googleServiceAccount': {
+      const googleServiceAccountAuth = new GoogleServiceAccountStrategy();
+      return await googleServiceAccountAuth.getCredential();
+    }
+    case 'oidc': {
+      const oidcAuth=new OidcStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for OIDC authentication',
+        );
+      }
+      const oidcAuthConfig = authConfig
+        ?.getOptionalConfig('oidc')
+        ?.getOptionalConfig(authEnvironment);
+      if (!oidcAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for OIDC in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        oidcTokenProvider: oidcAuthConfig?.getOptionalString('oidcTokenProvider'),
+      };
+      return await oidcAuth.getCredential(cluster, requestAuth);
+    }
+    case 'serviceAccount': {
+      const serviceAccountAuth=new ServiceAccountStrategy();
+      return await serviceAccountAuth.getCredential(cluster);
+    }
+    default:
+      throw new Error(`Unsupported authentication provider: ${authProvider}`);
+  }
+}

--- a/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
@@ -11,35 +11,8 @@ import {
   HttpAuthService,
   AuthService,
 } from '@backstage/backend-plugin-api';
-import { ClusterDetails } from '@backstage/plugin-kubernetes-node';
 import { ANNOTATION_KUBERNETES_AUTH_PROVIDER } from '@backstage/plugin-kubernetes-common';
-
-// Add new type definitions for auth providers
-type AuthProvider = 'serviceAccount' | 'google' | 'aws' | 'azure' | 'oidc';
-
-// Auth metadata type definitions
-type AuthMetadataValue = string | Record<string, unknown>;
-
-// Define the shape of auth metadata with a string index signature that allows undefined
-interface KubernetesAuthMetadata {
-  [key: string]: AuthMetadataValue | undefined;
-}
-
-// Define specific auth metadata interface that extends the base one
-interface ExtendedKubernetesAuthMetadata extends KubernetesAuthMetadata {
-  serviceAccountToken?: string;
-  google?: Record<string, unknown>;
-  azure?: Record<string, unknown>;
-  oidc?: Record<string, unknown>;
-  'kubernetes.io/aws-assume-role'?: string;
-  'kubernetes.io/aws-external-id'?: string;
-  'kubernetes.io/x-k8s-aws-id'?: string;
-}
-
-interface KubernetesClusterDetails extends Omit<ClusterDetails, 'authMetadata'> {
-  authProvider?: AuthProvider;
-  authMetadata: ExtendedKubernetesAuthMetadata;
-}
+import { getAuthCredential } from '../auth';
 
 type ObjectToFetch = {
   group: string;
@@ -58,7 +31,10 @@ export class XrdDataProvider {
   httpAuth: HttpAuthService;
 
   private getAnnotationPrefix(): string {
-    return this.config.getOptionalString('kubernetesIngestor.annotationPrefix') || 'terasky.backstage.io';
+    return (
+      this.config.getOptionalString('kubernetesIngestor.annotationPrefix') ||
+      'terasky.backstage.io'
+    );
   }
 
   constructor(
@@ -68,7 +44,7 @@ export class XrdDataProvider {
     discovery: DiscoveryService,
     permissions: PermissionEvaluator,
     auth: AuthService,
-    httpAuth: HttpAuthService
+    httpAuth: HttpAuthService,
   ) {
     this.logger = logger;
     this.config = config;
@@ -103,26 +79,42 @@ export class XrdDataProvider {
         return [];
       }
 
-      const ingestAllXRDs = this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.ingestAllXRDs') ?? false;
+      const ingestAllXRDs =
+        this.config.getOptionalBoolean(
+          'kubernetesIngestor.crossplane.xrds.ingestAllXRDs',
+        ) ?? false;
 
       let allFetchedObjects: any[] = [];
       const xrdMap = new Map<string, any>();
 
       for (const cluster of clusters) {
         // Get the auth provider type from the cluster config
-        const authProvider = cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] || 'serviceAccount';
+        const authProvider =
+          cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||
+          'serviceAccount';
 
         // Get the auth credentials based on the provider type
         let credential;
         try {
-          credential = await this.getAuthCredential(cluster, authProvider);
+          credential = await getAuthCredential(
+            cluster,
+            authProvider,
+            this.config,
+            this.logger,
+          );
         } catch (error) {
           if (error instanceof Error) {
-            this.logger.error(`Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`, error);
+            this.logger.error(
+              `Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`,
+              error,
+            );
           } else {
-            this.logger.error(`Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`, {
-              error: String(error),
-            });
+            this.logger.error(
+              `Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`,
+              {
+                error: String(error),
+              },
+            );
           }
           continue;
         }
@@ -154,25 +146,34 @@ export class XrdDataProvider {
             })),
           );
           const prefix = this.getAnnotationPrefix();
-          const filteredObjects = fetchedResources.filter(resource => {
-            if (resource.metadata.annotations?.[`${prefix}/exclude-from-catalog`]) {
-              return false;
-            }
+          const filteredObjects = fetchedResources
+            .filter(resource => {
+              if (
+                resource.metadata.annotations?.[
+                `${prefix}/exclude-from-catalog`
+                ]
+              ) {
+                return false;
+              }
 
-            if (!ingestAllXRDs && !resource.metadata.annotations?.[`${prefix}/add-to-catalog`]) {
-              return false;
-            }
+              if (
+                !ingestAllXRDs &&
+                !resource.metadata.annotations?.[`${prefix}/add-to-catalog`]
+              ) {
+                return false;
+              }
 
-            if (!resource.spec?.claimNames?.kind) {
-              return false;
-            }
+              if (!resource.spec?.claimNames?.kind) {
+                return false;
+              }
 
-            return true;
-          }).map(resource => ({
-            ...resource,
-            clusterName: cluster.name, // Attach the cluster name to the resource
-            clusterEndpoint: cluster.url, // Attach the cluster endpoint to the resource
-          }));
+              return true;
+            })
+            .map(resource => ({
+              ...resource,
+              clusterName: cluster.name, // Attach the cluster name to the resource
+              clusterEndpoint: cluster.url, // Attach the cluster endpoint to the resource
+            }));
 
           allFetchedObjects = allFetchedObjects.concat(filteredObjects);
 
@@ -209,12 +210,22 @@ export class XrdDataProvider {
           allFetchedObjects.forEach(xrd => {
             const xrdName = xrd.metadata.name;
             if (!xrdMap.has(xrdName)) {
-              xrdMap.set(xrdName, { ...xrd, clusters: [xrd.clusterName], clusterDetails: [{name: xrd.clusterName, url: xrd.clusterEndpoint}], compositions: [] });
+              xrdMap.set(xrdName, {
+                ...xrd,
+                clusters: [xrd.clusterName],
+                clusterDetails: [
+                  { name: xrd.clusterName, url: xrd.clusterEndpoint },
+                ],
+                compositions: [],
+              });
             } else {
               const existingXrd = xrdMap.get(xrdName);
               if (!existingXrd.clusters.includes(xrd.clusterName)) {
                 existingXrd.clusters.push(xrd.clusterName);
-                existingXrd.clusterDetails.push({name: xrd.clusterName, url: xrd.clusterEndpoint});
+                existingXrd.clusterDetails.push({
+                  name: xrd.clusterName,
+                  url: xrd.clusterEndpoint,
+                });
               }
             }
           });
@@ -222,8 +233,9 @@ export class XrdDataProvider {
           // Add compositions to the corresponding XRDs
           fetchedCompositions.forEach(composition => {
             const { apiVersion, kind } = composition.spec.compositeTypeRef;
-            xrdMap.forEach((xrd) => {
-              const { apiVersion: xrdApiVersion, kind: xrdKind } = xrd.status.controllers.compositeResourceType;
+            xrdMap.forEach(xrd => {
+              const { apiVersion: xrdApiVersion, kind: xrdKind } =
+                xrd.status.controllers.compositeResourceType;
               if (apiVersion === xrdApiVersion && kind === xrdKind) {
                 if (!xrd.compositions.includes(composition.metadata.name)) {
                   xrd.compositions.push(composition.metadata.name);
@@ -231,81 +243,31 @@ export class XrdDataProvider {
               }
             });
           });
-
         } catch (clusterError) {
           if (clusterError instanceof Error) {
-            this.logger.error(`Failed to fetch XRD objects for cluster ${cluster.name}: ${clusterError.message}`, clusterError);
+            this.logger.error(
+              `Failed to fetch XRD objects for cluster ${cluster.name}: ${clusterError.message}`,
+              clusterError,
+            );
           } else {
-            this.logger.error(`Failed to fetch XRD objects for cluster ${cluster.name}:`, {
-              error: String(clusterError),
-            });
+            this.logger.error(
+              `Failed to fetch XRD objects for cluster ${cluster.name}:`,
+              {
+                error: String(clusterError),
+              },
+            );
           }
         }
       }
 
-      this.logger.debug(`Total fetched XRD objects: ${allFetchedObjects.length}`);
+      this.logger.debug(
+        `Total fetched XRD objects: ${allFetchedObjects.length}`,
+      );
 
       return Array.from(xrdMap.values());
     } catch (error) {
       this.logger.error('Error fetching XRD objects');
       throw error;
-    }
-  }
-
-  private async getAuthCredential(cluster: KubernetesClusterDetails, authProvider: string): Promise<any> {
-    switch (authProvider) {
-      case 'serviceAccount': {
-        const token = cluster.authMetadata?.serviceAccountToken;
-        if (!token) {
-          throw new Error('Service account token not found in cluster auth metadata');
-        }
-        return { type: 'bearer token', token };
-      }
-      case 'google': {
-        // For Google authentication (both client and server-side)
-        const googleAuth = cluster.authMetadata?.google;
-        if (googleAuth) {
-          return {
-            type: 'google',
-            ...googleAuth,
-          };
-        }
-        throw new Error('Google auth metadata not found in cluster configuration');
-      }
-      case 'aws': {
-        // For AWS authentication
-        const awsRole = cluster.authMetadata?.['kubernetes.io/aws-assume-role'];
-        if (!awsRole) {
-          throw new Error('AWS role ARN not found in cluster auth metadata');
-        }
-        return {
-          type: 'aws',
-          assumeRole: awsRole,
-          externalId: cluster.authMetadata?.['kubernetes.io/aws-external-id'],
-          clusterAwsId: cluster.authMetadata?.['kubernetes.io/x-k8s-aws-id'],
-        };
-      }
-      case 'azure': {
-        // For Azure authentication (both AKS and server-side)
-        const azureAuth = cluster.authMetadata?.azure || {};
-        return {
-          type: 'azure',
-          ...azureAuth,
-        };
-      }
-      case 'oidc': {
-        // For OIDC authentication
-        const oidcAuth = cluster.authMetadata?.oidc;
-        if (!oidcAuth) {
-          throw new Error('OIDC configuration not found in cluster auth metadata');
-        }
-        return {
-          type: 'oidc',
-          ...oidcAuth,
-        };
-      }
-      default:
-        throw new Error(`Unsupported authentication provider: ${authProvider}`);
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35769,11 +35769,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
   version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/c891ccf04008bc1305ba34053db951f8a4584b4a1bf2f68fd972c4a354df3dc5e62c8bfed4f6ac2d12e5b3b1c49af312c83a651048f818cd5b4949d17baacd79
+  checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Updating Kubernetes AuthProvider, for all existing **authProvider** supported by **[Kubernetes Plugin](https://backstage.io/docs/features/kubernetes/configuration#clusterlocatormethods)**

**Problem:**

Currently credential provider is just authorizing as anonymous user, if someone configure their cluster to be accessed by a particular role, plugin is failing to authorize, as the required permission is linked to a particular username (not anonymous). After my last update its able to authenticate to Clusters but only as **anonymous user**.

**Update:**

Credentials provider for each of the processors is updated and replaced with a common credential provider, which is relating to all the authProvider supported by Backstage Kubernetes Plugin. [Reference](https://github.com/backstage/backstage/tree/master/plugins/kubernetes-backend/src/auth).

**Testing:**

I tested the update with my environment, which currently have access to **authProvider: serviceAccount & AWS**, requesting to test for other authProviders also.

In my environment, everything (CRDs, XRDs, Default Kubernetes Workloads) works, fine with restricting access to a particular role, which lacks earlier.

Please review this, and let me know if anything needs to be updated.