### PR TITLE
Adds option to allow-list clusters to ingest resources from

### DIFF
--- a/plugins/kubernetes-ingestor/README.md
+++ b/plugins/kubernetes-ingestor/README.md
@@ -50,6 +50,9 @@ kubernetesIngestor:
     titleModel: 'name' # name, name-cluster, name-namespace
     systemModel: 'namespace' # cluster, namespace, cluster-namespace, default
     referencesNamespaceModel: 'default' # default, same
+  # A list of cluster names to ingest resources from. If empty, resources from all clusters under kubernetes.clusterLocatorMethods.clusters will be ingested.
+  # allowedClusterNames:
+  #   - my-cluster-name
   components:
     # Whether to enable creation of backstage components for Kubernetes workloads
     enabled: true

--- a/plugins/kubernetes-ingestor/src/provider/CRDDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/CRDDataProvider.ts
@@ -70,8 +70,12 @@ export class CRDDataProvider {
       }
 
       const crdMap = new Map<string, any>();
-
+      const allowedClusters = this.config.getOptionalStringArray("kubernetesIngestor.allowedClusterNames");
       for (const cluster of clusters) {
+        if (allowedClusters && !allowedClusters.includes(cluster.name)) {
+          this.logger.debug(`Skipping cluster: ${cluster.name} as it is not included in the allowedClusterNames configuration.`);
+          continue;
+        }
         // Get the auth provider type from the cluster config
         const authProvider =
           cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||

--- a/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
@@ -157,7 +157,12 @@ export class KubernetesDataProvider {
           'kubernetesIngestor.components.onlyIngestAnnotatedResources',
         ) ?? false;
 
+      const allowedClusters = this.config.getOptionalStringArray("kubernetesIngestor.allowedClusterNames");
       for (const cluster of clusters as ExtendedClusterDetails[]) {
+        if (allowedClusters && !allowedClusters.includes(cluster.name)) {
+          this.logger.debug(`Skipping cluster: ${cluster.name} as it is not included in the allowedClusterNames configuration.`);
+          continue;
+        }
         // Get the auth provider type from the cluster config
         const authProvider =
           cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||
@@ -426,7 +431,12 @@ export class KubernetesDataProvider {
 
       const crdMapping: Record<string, string> = {};
 
+      const allowedClusters = this.config.getOptionalStringArray("kubernetesIngestor.allowedClusterNames");
       for (const cluster of clusters as ExtendedClusterDetails[]) {
+        if (allowedClusters && !allowedClusters.includes(cluster.name)) {
+          this.logger.debug(`Skipping cluster: ${cluster.name} as it is not included in the allowedClusterNames configuration.`);
+          continue;
+        }
         // Get the auth provider type from the cluster config
         const authProvider =
           cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||

--- a/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
@@ -86,8 +86,12 @@ export class XrdDataProvider {
 
       let allFetchedObjects: any[] = [];
       const xrdMap = new Map<string, any>();
-
+      const allowedClusters = this.config.getOptionalStringArray("kubernetesIngestor.allowedClusterNames");
       for (const cluster of clusters) {
+        if (allowedClusters && !allowedClusters.includes(cluster.name)) {
+          this.logger.debug(`Skipping cluster: ${cluster.name} as it is not included in the allowedClusterNames configuration.`);
+          continue;
+        }
         // Get the auth provider type from the cluster config
         const authProvider =
           cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||


### PR DESCRIPTION
Introduce the new optional configuration property `kubernetesIngestor.allowedClusterNames`. The property is a list of cluster names from which resources should be ingested from. If the property is not set, resources from all configured clusters under `kubernetes.clusterLocatorMethods.clusters` will be ingested.

Example plugin configuration:
```
kubernetesIngestor:
  allowedClusterNames:
    - aks-prod
    - k8s-prod
```