### PR TITLE
feat(plugin): kubernetes-ingestor to use globalAuthStrategies for kubernetes when using custom auth plugins

### DIFF
--- a/plugins/kubernetes-ingestor/src/provider/CRDDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/CRDDataProvider.ts
@@ -40,6 +40,14 @@ export class CRDDataProvider {
         discovery: this.discovery,
       });
 
+      const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+      if (globalAuthStrategies) {
+        for (const [key, strategy] of globalAuthStrategies) {
+          this.logger.debug(`Adding auth strategy: ${key}`);
+          builder.addAuthStrategy(key, strategy);
+        }
+      }
+
       const { fetcher, clusterSupplier } = await builder.build();
       const credentials = {
         $$type: '@backstage/BackstageCredentials' as const,

--- a/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
@@ -68,6 +68,14 @@ export class KubernetesDataProvider {
         discovery: this.discovery,
       });
 
+      const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+      if (globalAuthStrategies) {
+        for (const [key, strategy] of globalAuthStrategies) {
+          this.logger.debug(`Adding auth strategy: ${key}`);
+          builder.addAuthStrategy(key, strategy);
+        }
+      }
+
       const { fetcher, clusterSupplier } = await builder.build();
 
       const credentials: BackstageCredentials = {
@@ -414,6 +422,14 @@ export class KubernetesDataProvider {
         permissions: this.permissions,
         discovery: this.discovery,
       });
+
+      const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+      if (globalAuthStrategies) {
+        for (const [key, strategy] of globalAuthStrategies) {
+          this.logger.debug(`Adding auth strategy: ${key}`);
+          builder.addAuthStrategy(key, strategy);
+        }
+      }
 
       const { fetcher, clusterSupplier } = await builder.build();
 

--- a/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
@@ -65,6 +65,14 @@ export class XrdDataProvider {
         discovery: this.discovery,
       });
 
+      const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+      if (globalAuthStrategies) {
+        for (const [key, strategy] of globalAuthStrategies) {
+          this.logger.debug(`Adding auth strategy: ${key}`);
+          builder.addAuthStrategy(key, strategy);
+        }
+      }
+
       const { fetcher, clusterSupplier } = await builder.build();
 
       const credentials = {


### PR DESCRIPTION
### Description of your changes
use globalAuthStrategies for kubernetes to fix:

```
{"level":"info","message":"action=LoadingCustomResources numOfCustomResources=0","plugin":"catalog","service":"backstage"}
{"level":"error","message":"Error fetching Kubernetes objects Invalid cluster 'test-xyz': authProvider \"haarchri\" has no config associated with it"}
```

Fixes: #44 

### How has this code been tested
- tested with valid tokens and custom auth provider
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/442fb834-8670-4d80-b7d1-ed6ed9f53dd3" />

```
Loading config from MergedConfigSource{FileConfigSource{path="/app/app-config-from-configmap.yaml"}, EnvConfigSource{count=1}}
{"level":"info","message":"Found 1 new secrets in config that will be redacted","service":"backstage"}
{"level":"info","message":"Listening on :7007","service":"rootHttpRouter"}
{"level":"info","message":"Plugin initialization started: 'app', 'proxy', 'scaffolder', 'techdocs', 'auth', 'kubernetes', 'crossplane', 'catalog', 'permission', 'search'","service":"backstage","type":"initialization"}

{"apiGroup":"tokenexchange.upbound.io","apiVersion":"v1alpha1","audienceCount":2,"authHost":"auth.upbound.io","level":"info","message":"UpboundStrategy initialized","plugin":"kubernetes","service":"backstage"}
{"level":"info","message":"Registered Upbound authentication strategy for Kubernetes","plugin":"kubernetes","service":"backstage"}

{"level":"info","message":"Task worker starting: KubernetesEntityProvider, {\"version\":2,\"cadence\":\"PT10S\",\"timeoutAfterDuration\":\"PT600S\"}","plugin":"catalog","service":"backstage","task":"KubernetesEntityProvider"}
{"level":"info","message":"Task worker starting: XRDTemplateEntityProvider, {\"version\":2,\"cadence\":\"PT10S\",\"timeoutAfterDuration\":\"PT600S\"}","plugin":"catalog","service":"backstage","task":"XRDTemplateEntityProvider"}
{"level":"info","message":"Initializing Kubernetes backend","plugin":"catalog","service":"backstage"}
{"level":"info","message":"action=LoadingCustomResources numOfCustomResources=9","plugin":"catalog","service":"backstage"}
{"level":"info","message":"Initializing Kubernetes backend","plugin":"catalog","service":"backstage"}
{"level":"info","message":"action=LoadingCustomResources numOfCustomResources=9","plugin":"catalog","service":"backstage"}

```

- tested with invalid tokens and custom auth provider

```
Loading config from MergedConfigSource{FileConfigSource{path="/app/app-config-from-configmap.yaml"}, EnvConfigSource{count=1}}
{"level":"info","message":"Found 1 new secrets in config that will be redacted","service":"backstage"}
{"level":"info","message":"Listening on :7007","service":"rootHttpRouter"}
{"level":"info","message":"Plugin initialization started: 'app', 'proxy', 'scaffolder', 'techdocs', 'auth', 'kubernetes', 'crossplane', 'catalog', 'permission', 'search'","service":"backstage","type":"initialization"}

{"level":"info","message":"action=LoadingCustomResources numOfCustomResources=0","plugin":"catalog","service":"backstage"}
{"errorBody":"{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n","level":"error","message":"Token exchange request failed","organization":"chaar","plugin":"kubernetes","service":"backstage","status":401,"statusText":"Unauthorized"}
{"authHost":"auth.upbound.io","clusterName":"haarchri-ctp","errorMessage":"HTTP 401: Unauthorized. {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n","errorName":"Error","level":"error","message":"Failed to get Upbound org-scoped token","organization":"chaar","plugin":"kubernetes","service":"backstage"}
{"level":"error","message":"Failed to get auth credentials for cluster haarchri-ctp with provider upbound: Failed to authenticate with Upbound: HTTP 401: Unauthorized. {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n","plugin":"catalog","service":"backstage","stack":"Error: Failed to authenticate with Upbound: HTTP 401: Unauthorized. {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n\n    at UpboundStrategy.getCredential (/app/plugins/kubernetes-backend-module-upbound/dist/UpboundStrategy.cjs.js:75:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.getAuthCredential (/app/plugins/kubernetes-ingestor/dist/auth/kubernetesCredentialProvider.cjs.js:10:12)\n    at async KubernetesDataProvider.fetchKubernetesObjects (/app/plugins/kubernetes-ingestor/dist/provider/KubernetesDataProvider.cjs.js:123:24)\n    at async KubernetesEntityProvider.run (/app/plugins/kubernetes-ingestor/dist/provider/EntityProvider.cjs.js:1672:32)\n    at async Object.fn (/app/plugins/kubernetes-ingestor/dist/provider/EntityProvider.cjs.js:1655:9)\n    at async /app/node_modules/@backstage/backend-defaults/dist/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.cjs.js:111:13\n    at async TaskWorker.fn (/app/node_modules/@backstage/backend-defaults/dist/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.cjs.js:108:9)\n    at async TaskWorker.runOnce (/app/node_modules/@backstage/backend-defaults/dist/entrypoints/scheduler/lib/TaskWorker.cjs.js:100:7)\n    at async /app/node_modules/@backstage/backend-defaults/dist/entrypoints/scheduler/lib/TaskWorker.cjs.js:48:31"}
{"level":"info","message":"Initializing Kubernetes backend","plugin":"catalog","service":"backstage"}
{"level":"info","message":"action=LoadingCustomResources numOfCustomResources=0","plugin":"catalog","service":"backstage"}
{"errorBody":"{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Unauthorized\",\"reason\":\"Unauthorized\",\"code\":401}\n","level":"error","message":"Token exchange request failed","organization":"chaar","plugin":"kubernetes","service":"backstage","status":401,"statusText":"Unauthorized"}
```



