### PR TITLE
fix(ingestor): kind-singular

### DIFF
--- a/plugins/kubernetes-ingestor/README.md
+++ b/plugins/kubernetes-ingestor/README.md
@@ -23,7 +23,6 @@ Add the plugin to your Backstage project by running:
   ```
   * Add to backend (packages/backend/src/index.ts)
   ```javascript
-  
   backend.add(import('@terasky/backstage-plugin-kubernetes-ingestor'));
   backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
   backend.add(import('@backstage/plugin-scaffolder-backend-module-gitlab'));
@@ -36,7 +35,7 @@ Add the plugin to your Backstage project by running:
 * available config options:
 ```yaml
 kubernetesIngestor:
-  # Mappings of kubernetes resource metadata to backstage entity metadata 
+  # Mappings of kubernetes resource metadata to backstage entity metadata
   # The list bellow are the default values when the mappings are not set in the app-config.yaml
   # The recommended values are:
   # namespaceModel: 'cluster' # cluster, namespace, default
@@ -60,9 +59,9 @@ kubernetesIngestor:
       # How often to query the clusters for data
       frequency: 10
       # Max time to process the data per cycle
-      timeout: 600 
+      timeout: 600
     # Namespaces to exclude the resources from
-    excludedNamespaces: 
+    excludedNamespaces:
       - kube-public
       - kube-system
     # Custom Resource Types to also generate components for
@@ -70,6 +69,7 @@ kubernetesIngestor:
       - group: pkg.crossplane.io
         apiVersion: v1
         plural: providers
+        # singular: provider # explicit singular form - needed when auto-detection fails
     # By default all standard kubernetes workload types are ingested. This allows you to disable this behavior
     disableDefaultWorkloadTypes: false
     # Allows ingestion to be opt-in or opt-out by either requiring or not a dedicated annotation to ingest a resource (terasky.backstage.io/add-to-catalog or terasky.backstage.io/exclude-from-catalog)
@@ -87,7 +87,7 @@ kubernetesIngestor:
         target: github
         git:
           # Follows the backstage standard format which is github.com?owner=<REPO OWNER>&repo=<REPO NAME>
-          repoUrl: 
+          repoUrl:
           targetBranch: main
         # Whether the user should be able to select the repo they want to push the manifest to or not
         allowRepoSelection: true
@@ -97,7 +97,7 @@ kubernetesIngestor:
         # How often to query the clusters for data
         frequency: 10
         # Max time to process the data per cycle
-        timeout: 600 
+        timeout: 600
       # Allows ingestion to be opt-in or opt-out by either requiring or not a dedicated annotation to ingest a xrd (terasky.backstage.io/add-to-catalog or terasky.backstage.io/exclude-from-catalog)
       ingestAllXRDs: true
       # Will convert default values from the XRD into placeholders in the UI instead of always adding them to the generated manifest.
@@ -111,7 +111,7 @@ kubernetesIngestor:
       target: github
       git:
         # Follows the backstage standard format which is github.com?owner=<REPO OWNER>&repo=<REPO NAME>
-        repoUrl: 
+        repoUrl:
         targetBranch: main
       # Whether the user should be able to select the repo they want to push the manifest to or not
       allowRepoSelection: true

--- a/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
@@ -19,6 +19,7 @@ type ObjectToFetch = {
   group: string;
   apiVersion: string;
   plural: string;
+  singular?: string;
   objectType: KubernetesObjectTypes;
 };
 
@@ -131,6 +132,7 @@ export class KubernetesDataProvider {
             group: type.getString('group'),
             apiVersion: type.getString('apiVersion'),
             plural: type.getString('plural'),
+            singular: type.getOptionalString('singular'),
             objectType: type.getString('plural') as KubernetesObjectTypes,
           })) || [];
 
@@ -305,7 +307,7 @@ export class KubernetesDataProvider {
                   return {
                     ...resource,
                     apiVersion: `${objectType.group}/${objectType.apiVersion}`,
-                    kind: objectType.plural?.slice(0, -1),
+                    kind: objectType.singular || pluralize.singular(objectType.plural) || objectType.plural?.slice(0, -1),
                     clusterName: cluster.name,
                     compositionData: {
                       name: resource.spec.compositionRef.name,
@@ -316,7 +318,7 @@ export class KubernetesDataProvider {
                 return {
                   ...resource,
                   apiVersion: `${objectType.group}/${objectType.apiVersion}`,
-                  kind: objectType.plural?.slice(0, -1),
+                  kind: objectType.singular || pluralize.singular(objectType.plural) || objectType.plural?.slice(0, -1),
                   clusterName: cluster.name,
                 };
               }),


### PR DESCRIPTION
fix the kind singular issue 
Component Overview looks now like: 
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/af90a12d-03c7-4a11-996b-5039f4cae7c0" />

we added an singular optional option for the ingestor config, we will use pluralize.singular as fallback 1 and fallback to the old behav. just in cases

      kubernetesIngestor:
        mappings:
          systemModel: "cluster-namespace"
        components:
          customWorkloadTypes:
            - group: "aws.platform.upbound.io"
              apiVersion: "v1alpha1"
              plural: "xeks"
              singular: "xeks"
            - group: "aws.platform.upbound.io"
              apiVersion: "v1alpha1"
              plural: "xnetworks"
            - group: "aws.platform.upbound.io"
              apiVersion: "v1alpha1"
              plural: "xpodidentities"
            - group: "pkg.crossplane.io"
              apiVersion: "v1"
              plural: "providers"

Fixes: #43