### PR TITLE
Adding use of kubernetes  v2 api and falling back to v2beta1 if not available

### DIFF
--- a/plugins/crossplane-resources/src/components/CrossplaneV1ResourceGraph.tsx
+++ b/plugins/crossplane-resources/src/components/CrossplaneV1ResourceGraph.tsx
@@ -764,7 +764,7 @@ const CrossplaneV1ResourceGraph = () => {
                     init: {
                         method: 'GET',
                         headers: {
-                            'Accept': 'application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json',
+                            'Accept': 'application/json;as=APIGroupDiscoveryList;v=v2;g=apidiscovery.k8s.io,application/json;as=APIGroupDiscoveryList;v=v2beta1;g=apidiscovery.k8s.io,application/json',
                         },
                     },
                 });


### PR DESCRIPTION
Hello,

Since the 2.0.0 crossplane resource frontend and the use of new component name "CrossplaneV1ResourceGraph", the ability to use kubernetes v2 apis and falling back to v2beta1 if not available has not been added as it has been done for "LegacyCrossplaneV1ResourceGraph".

Regards,