### PR TITLE
scaffolder: use empty string as namespace path component for inputs w…

### DIFF
--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/crd-templating.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/crd-templating.ts
@@ -128,7 +128,7 @@ export function createCrdTemplateAction({config}: {config: any}) {
       input.clusters.forEach((cluster: string) => {
         const filePath = path.join(
           cluster,
-          (input.parameters as any)[input.namespaceParam || 'namespace'],
+          (input.parameters as any)[input.namespaceParam || 'namespace'] || "",
           input.kind,
           `${(input.parameters as any)[input.nameParam]}.yaml`
         );


### PR DESCRIPTION
…ithout ns

this is needed for the scaffolder to work properly with cluster-scoped custom resources