### PR TITLE
Fix yarn command syntax in installation instructions

### DIFF
--- a/site/docs/plugins/kro/frontend/install.md
+++ b/site/docs/plugins/kro/frontend/install.md
@@ -12,7 +12,7 @@
 
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/app @terasky/backstage-plugin-kro-resources-frontend
+yarn --cwd packages/app add @terasky/backstage-plugin-kro-resources-frontend
 ```
 
 ### 2. Import Components


### PR DESCRIPTION
The old command Will give error:

Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path

$ yarn add [--json] [-F,--fixed] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode #0] ...