### PR TITLE
fix: use configurable annotationPrefix for kubernetes resource metadata annotations

### DIFF
--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -2176,10 +2176,10 @@ export class KubernetesEntityProvider implements EntityProvider {
           ...Object.fromEntries(
             Object.entries(annotations).filter(([key]) => key !== `${prefix}/links`)
           ),
-          'terasky.backstage.io/kubernetes-resource-kind': resource.kind,
-          'terasky.backstage.io/kubernetes-resource-name': resource.metadata.name,
-          'terasky.backstage.io/kubernetes-resource-api-version': resource.apiVersion,
-          'terasky.backstage.io/kubernetes-resource-namespace': resource.metadata.namespace || '',
+          [`${prefix}/kubernetes-resource-kind`]: resource.kind,
+          [`${prefix}/kubernetes-resource-name`]: resource.metadata.name,
+          [`${prefix}/kubernetes-resource-api-version`]: resource.apiVersion,
+          [`${prefix}/kubernetes-resource-namespace`]: resource.metadata.namespace || '',
           ...customAnnotations,
           ...argoAnnotations,
           ...(systemNameModel === 'cluster-namespace' || systemNamespaceModel === 'cluster' ? {

--- a/plugins/kubernetes-resources/config.d.ts
+++ b/plugins/kubernetes-resources/config.d.ts
@@ -6,10 +6,17 @@ export interface Config {
     */
     kubernetesResources?: {
       /**
-      * Enable permission frameowrk checks
+      * Enable permission framework checks
       * NOTE: Visibility applies to only this field
       * @visibility frontend
       */
-      enablePermissions: boolean;
+      enablePermissions?: boolean;
+      /**
+      * Annotation prefix for kubernetes resource annotations.
+      * Must match the prefix configured in kubernetes-ingestor.
+      * @default 'terasky.backstage.io'
+      * @visibility frontend
+      */
+      annotationPrefix?: string;
     }
-  }  
+  }

--- a/plugins/kubernetes-resources/src/alpha.tsx
+++ b/plugins/kubernetes-resources/src/alpha.tsx
@@ -1,16 +1,12 @@
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { EntityCardBlueprint, EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { Entity } from '@backstage/catalog-model';
-
-const isKubernetesAvailable = (entity: Entity) => {
-  return Boolean(entity.metadata.annotations?.['terasky.backstage.io/kubernetes-resource-name']);
-};
+import { isKubernetesResourcesAvailable } from './components/isKubernetesResourcesAvailable';
 
 /** @alpha */
 export const kubernetesResourcesGraphCard = EntityCardBlueprint.make({
   name: 'kubernetes-resources.graph',
   params: {
-    filter: isKubernetesAvailable,
+    filter: isKubernetesResourcesAvailable,
     loader: () => import('./components/KubernetesResourceGraph').then(m => <m.default />),
   },
   disabled: false,
@@ -22,7 +18,7 @@ export const kubernetesResourcesContent = EntityContentBlueprint.make({
   params: {
     path: '/kubernetes-resources',
     title: 'Kubernetes Resources',
-    filter: isKubernetesAvailable,
+    filter: isKubernetesResourcesAvailable,
     loader: () => import('./components/KubernetesResourcesPage').then(m => <m.default />),
   },
   disabled: false,

--- a/plugins/kubernetes-resources/src/components/KubernetesResourceGraph.tsx
+++ b/plugins/kubernetes-resources/src/components/KubernetesResourceGraph.tsx
@@ -82,6 +82,7 @@ const KubernetesResourceGraph = () => {
     const configApi = useApi(configApiRef); // Move this to the top level
     const config = useApi(configApiRef);
     const enablePermissions = config.getOptionalBoolean('kubernetesResources.enablePermissions') ?? false;
+    const annotationPrefix = config.getOptionalString('kubernetesResources.annotationPrefix') ?? 'terasky.backstage.io';
     const [resources, setResources] = useState<Array<KubernetesObject>>([]);
     const [selectedResource, setSelectedResource] = useState<KubernetesObject | null>(null);
     const [drawerOpen, setDrawerOpen] = useState(false);
@@ -215,10 +216,10 @@ const KubernetesResourceGraph = () => {
 
         const fetchResources = async () => {
             const annotations = entity.metadata.annotations || {};
-            const resourceName = annotations['terasky.backstage.io/kubernetes-resource-name'];
-            const resourceKind = annotations['terasky.backstage.io/kubernetes-resource-kind'];
-            const resourceApiVersion = annotations['terasky.backstage.io/kubernetes-resource-api-version'];
-            const resourceNamespace = annotations['terasky.backstage.io/kubernetes-resource-namespace'];
+            const resourceName = annotations[`${annotationPrefix}/kubernetes-resource-name`];
+            const resourceKind = annotations[`${annotationPrefix}/kubernetes-resource-kind`];
+            const resourceApiVersion = annotations[`${annotationPrefix}/kubernetes-resource-api-version`];
+            const resourceNamespace = annotations[`${annotationPrefix}/kubernetes-resource-namespace`];
             const clusterName = annotations['backstage.io/managed-by-origin-location']?.split(': ')[1];
 
             if (!resourceName || !resourceKind || !resourceApiVersion || !clusterName) {

--- a/plugins/kubernetes-resources/src/components/KubernetesResourcesPage.tsx
+++ b/plugins/kubernetes-resources/src/components/KubernetesResourcesPage.tsx
@@ -119,6 +119,7 @@ const KubernetesResourcesPage = () => {
     const configApi = useApi(configApiRef); // Move this to the top level
     const config = useApi(configApiRef);
     const enablePermissions = config.getOptionalBoolean('kubernetesResources.enablePermissions') ?? false;
+    const annotationPrefix = config.getOptionalString('kubernetesResources.annotationPrefix') ?? 'terasky.backstage.io';
     const [resources, setResources] = useState<Array<ExtendedKubernetesObject>>([]);
     const [selectedResource, setSelectedResource] = useState<ExtendedKubernetesObject | null>(null);
     const [drawerOpen, setDrawerOpen] = useState(false);
@@ -201,10 +202,10 @@ const KubernetesResourcesPage = () => {
 
         const fetchResources = async () => {
             const annotations = entity.metadata.annotations || {};
-            const resourceName = annotations['terasky.backstage.io/kubernetes-resource-name'];
-            const resourceKind = annotations['terasky.backstage.io/kubernetes-resource-kind'];
-            const resourceApiVersion = annotations['terasky.backstage.io/kubernetes-resource-api-version'];
-            const resourceNamespace = annotations['terasky.backstage.io/kubernetes-resource-namespace'];
+            const resourceName = annotations[`${annotationPrefix}/kubernetes-resource-name`];
+            const resourceKind = annotations[`${annotationPrefix}/kubernetes-resource-kind`];
+            const resourceApiVersion = annotations[`${annotationPrefix}/kubernetes-resource-api-version`];
+            const resourceNamespace = annotations[`${annotationPrefix}/kubernetes-resource-namespace`];
             const clusterName = annotations['backstage.io/managed-by-origin-location']?.split(': ')[1];
 
             if (!resourceName || !resourceKind || !resourceApiVersion || !clusterName) {

--- a/plugins/kubernetes-resources/src/components/isKubernetesResourcesAvailable.tsx
+++ b/plugins/kubernetes-resources/src/components/isKubernetesResourcesAvailable.tsx
@@ -1,7 +1,13 @@
 import { Entity } from '@backstage/catalog-model';
 
-
-
-export const isKubernetesResourcesAvailable = (entity: Entity): boolean => {
-  return Boolean(entity.metadata.annotations?.['terasky.backstage.io/kubernetes-resource-name']);
+/**
+ * Check if kubernetes resources are available for an entity.
+ * @param entity - The entity to check
+ * @param annotationPrefix - The annotation prefix to use (default: 'terasky.backstage.io')
+ */
+export const isKubernetesResourcesAvailable = (
+  entity: Entity,
+  annotationPrefix: string = 'terasky.backstage.io'
+): boolean => {
+  return Boolean(entity.metadata.annotations?.[`${annotationPrefix}/kubernetes-resource-name`]);
 };


### PR DESCRIPTION
## Summary

Fixes #125

This PR makes the kubernetes resource metadata annotations use the configurable `annotationPrefix` instead of hardcoded `terasky.backstage.io`.

## Changes

### Backend (kubernetes-ingestor)
- `EntityProvider.ts`: Use `${prefix}` for kubernetes-resource-* annotations

### Frontend (kubernetes-resources)
- `config.d.ts`: Added `annotationPrefix` config option
- `KubernetesResourcesPage.tsx`: Use configurable prefix
- `KubernetesResourceGraph.tsx`: Use configurable prefix
- `isKubernetesResourcesAvailable.tsx`: Added optional `annotationPrefix` parameter
- `alpha.tsx`: Use shared `isKubernetesResourcesAvailable` function

## Configuration

```yaml
# app-config.yaml
kubernetesIngestor:
  annotationPrefix: 'mycompany.io'

kubernetesResources:
  annotationPrefix: 'mycompany.io'
```

## Backward Compatibility

- Default prefix remains `terasky.backstage.io`
- `isKubernetesResourcesAvailable` function signature uses optional parameter with default value