### PR TITLE
fix(kyverno) Pass all entity metadata to the backend

### DIFF
--- a/plugins/kyverno-common/src/types.ts
+++ b/plugins/kyverno-common/src/types.ts
@@ -1,5 +1,5 @@
 import { KubernetesObject } from '@backstage/plugin-kubernetes';
-import { Entity } from '@backstage/catalog-model';
+import { EntityMeta } from '@backstage/catalog-model';
 
 export interface PolicyReportSummary {
   error: number;
@@ -36,7 +36,9 @@ export interface PolicyReport {
 }
 
 export interface GetPolicyReportsRequest {
-  entity: Entity;
+  entity: {
+    metadata: EntityMeta;
+  };
 }
 
 export interface GetPolicyReportsResponse {
@@ -54,7 +56,9 @@ export interface GetPolicyResponse {
 }
 
 export interface GetCrossplanePolicyReportsRequest {
-  entity: Entity;
+  entity: {
+    metadata: EntityMeta;
+  };
 }
 
 export interface GetCrossplanePolicyReportsResponse {

--- a/plugins/kyverno-policy-reports-backend/src/actions.ts
+++ b/plugins/kyverno-policy-reports-backend/src/actions.ts
@@ -71,8 +71,6 @@ export function registerMcpActions(
 
         const reports = await service.getPolicyReports({
           entity: {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Component',
             metadata: input.entity.metadata,
           },
         });
@@ -197,8 +195,6 @@ export function registerMcpActions(
 
         const reports = await service.getCrossplanePolicyReports({
           entity: {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Component',
             metadata: input.entity.metadata,
           },
         });

--- a/plugins/kyverno-policy-reports/src/components/KyvernoCrossplaneOverviewCard.tsx
+++ b/plugins/kyverno-policy-reports/src/components/KyvernoCrossplaneOverviewCard.tsx
@@ -86,7 +86,9 @@ const KyvernoCrossplaneOverviewCard = () => {
       setLoading(true);
       try {
         const response = await kyvernoApi.getCrossplanePolicyReports({
-          entity: entity,
+          entity: {
+            metadata: entity.metadata,
+          },
         });
 
         const filteredReports = response.items;

--- a/plugins/kyverno-policy-reports/src/components/KyvernoCrossplanePolicyReportsTable.tsx
+++ b/plugins/kyverno-policy-reports/src/components/KyvernoCrossplanePolicyReportsTable.tsx
@@ -84,7 +84,9 @@ const KyvernoCrossplanePolicyReportsTable = () => {
             setLoading(true);
             try {
                 const response = await kyvernoApi.getCrossplanePolicyReports({
-                    entity: entity
+                    entity: {
+                        metadata: entity.metadata,
+                    }
                 });
                 setPolicyReports(response.items);
             } catch (error) {

--- a/plugins/kyverno-policy-reports/src/components/KyvernoOverviewCard.tsx
+++ b/plugins/kyverno-policy-reports/src/components/KyvernoOverviewCard.tsx
@@ -91,7 +91,9 @@ const KyvernoOverviewCard = () => {
         }
 
         const response = await kyvernoApi.getPolicyReports({
-          entity: entity,
+          entity: {
+            metadata: entity.metadata,
+          },
         });
 
         const filteredReports = response.items;

--- a/plugins/kyverno-policy-reports/src/components/KyvernoPolicyReportsTable.tsx
+++ b/plugins/kyverno-policy-reports/src/components/KyvernoPolicyReportsTable.tsx
@@ -86,7 +86,9 @@ const KyvernoPolicyReportsTable = () => {
                     throw new Error('Entity must have a namespace');
                 }
                 const response = await kyvernoApi.getPolicyReports({
-                    entity: entity
+                    entity: {
+                        metadata: entity.metadata,
+                    }
                 });
                 setPolicyReports(response.items);
             } catch (error) {


### PR DESCRIPTION
Fix for https://github.com/TeraSky-OSS/backstage-plugins/issues/131

The front end components need to pass complete entity metadata to the backend to ensure the kubernetes plugin is able to find all the relevant resources. The kubernetes API depends on entity annotations, without them it just returns empty results, meaning no policies are found for non-crossplane k8s resource.