### PR TITLE
feat(doc): Improve doc for customWorkloadTypes

### DIFF
--- a/site/docs/plugins/kubernetes-ingestor/backend/configure.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/configure.md
@@ -65,6 +65,7 @@ kubernetesIngestor:
         apiVersion: v1
         plural: providers
         # singular: provider # explicit singular form - needed when auto-detection fails
+        # defaultType: provider # Optional: fallback component type when annotation is missing. Default is service
     # By default all standard kubernetes workload types are ingested. This allows you to disable this behavior
     disableDefaultWorkloadTypes: false
     # Allows ingestion to be opt-in or opt-out by either requiring or not a dedicated annotation to ingest a resource (terasky.backstage.io/add-to-catalog or terasky.backstage.io/exclude-from-catalog)
@@ -837,12 +838,22 @@ components:
       apiVersion: v1
       plural: applications
       singular: application
-  
+      defaultType: app  # Optional: fallback component type when annotation is missing. Default is service
+
   # Exclude system namespaces
   excludedNamespaces:
     - kube-system
     - kube-public
 ```
+
+#### Default Type for Custom Workloads
+
+The `defaultType` field allows you to specify a fallback Backstage component type for custom workload types when the `terasky.backstage.io/component-type` annotation is not present on the resource.
+
+**Component type resolution priority:**
+1. **Annotation**: Use `terasky.backstage.io/component-type` annotation if present on the resource
+2. **defaultType**: Use the `defaultType` value from the custom workload configuration (if set)
+3. **Fallback**: Use `service` as the final default
 
 ## Crossplane Integration
 

--- a/site/docs/plugins/kubernetes-ingestor/backend/install.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/install.md
@@ -102,6 +102,7 @@ kubernetesIngestor:
       - group: pkg.crossplane.io
         apiVersion: v1
         plural: providers
+        defaultType: service  # Optional: fallback component type when annotation is missing 
 
   # Crossplane integration
   crossplane:


### PR DESCRIPTION
## Summary

Add documentation for the defaultType field in customWorkloadTypes configuration.

## Changes

install.md: Added example value and inline comment for defaultType field
configure.md:
Added defaultType field with examples in both customWorkloadTypes configuration blocks
Added new "Default Type for Custom Workloads" section explaining the feature and component type resolution priority

## Context

This documents the defaultType feature that allows specifying a fallback Backstage component type for custom workload types when the terasky.backstage.io/component-type annotation is not present on the resource.

Component type resolution priority:

Use terasky.backstage.io/component-type annotation if present
Use defaultType from config (if set)
Fall back to service
