### PR TITLE
feat(owner): Add owner component from namespace - Issues #144

### DIFF
--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -24,6 +24,15 @@ export interface Config {
      */
     defaultOwner?: string;
     /**
+     * Inherit owner annotation from Namespace when not set on workload
+     * When enabled, Components created from workloads will inherit the owner annotation
+     * from their Namespace if the workload doesn't have an explicit owner annotation.
+     * Annotation precedence: Workload annotation > Namespace annotation > Plugin default owner
+     * @default false
+     * @visibility frontend
+     */
+    inheritOwnerFromNamespace?: boolean;
+    /**
      * Ingest API entities as CRD type instead of OpenAPI type
      * When true, API entities will have type "crd" with the CRD YAML as definition
      * When false, API entities will have type "openapi" with generated OpenAPI spec

--- a/site/docs/plugins/kubernetes-ingestor/backend/configure.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/configure.md
@@ -817,6 +817,46 @@ kubernetesIngestor:
   defaultOwner: platform-engineering-team
 ```
 
+### Owner Inheritance from Namespace
+
+When `inheritOwnerFromNamespace` is enabled, Components created from workloads will automatically inherit the owner annotation from their Namespace if the workload doesn't have an explicit owner annotation.
+
+**Owner annotation precedence (highest to lowest):**
+1. **Workload annotation** - Explicit override on the workload resource
+2. **Namespace annotation** - Inherited from the Namespace (when enabled)
+3. **Plugin default owner** - Fallback to `kubernetesIngestor.defaultOwner`
+
+Default: `false`
+
+```yaml
+kubernetesIngestor:
+  inheritOwnerFromNamespace: false
+  defaultOwner: platform-engineering-team
+```
+
+**Use Case:**
+In organizations where namespaces represent team boundaries, this feature allows you to set the owner annotation once at the Namespace level instead of on each individual workload. For example, if all workloads in the `team-platform` namespace should be owned by `group:default/team-platform`, you can:
+
+1. Set the annotation on the Namespace:
+   ```yaml
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: team-platform
+     annotations:
+       terasky.backstage.io/owner: group:default/team-platform
+   ```
+
+2. Enable inheritance in the configuration:
+   ```yaml
+   kubernetesIngestor:
+     inheritOwnerFromNamespace: true
+   ```
+
+3. All workloads in that namespace will automatically inherit the owner from the namespace. Workload-level annotations can override the namespace-level owner if needed.
+
+**Note:** This feature only applies to namespaced resources. Cluster-scoped resources will continue to use the plugin default owner if no explicit annotation is set.
+
 ## Component Configuration
 
 ### Task Runner Settings


### PR DESCRIPTION
# Add Namespace-Level Owner Inheritance for Kubernetes Ingestor

Issues #144 

## Summary

This PR adds support for inheriting owner annotations from Kubernetes Namespace resources to Components created from workloads within that namespace. This reduces repetitive configuration in organizations where namespaces represent team boundaries.

## Problem Statement

Currently, to set the owner on a Component entity created by the Kubernetes Ingestor plugin, users must add the annotation `terasky.backstage.io/owner` on each individual workload (Deployment, StatefulSet, etc.).

In organizations where namespaces represent team boundaries, this creates repetitive configuration: every workload in a namespace belonging to "team-platform" needs the same owner annotation.

## Solution

Allow the `terasky.backstage.io/owner` annotation to be set at the Namespace level, with automatic inheritance to all Components created from workloads within that namespace.

### Annotation Precedence (highest to lowest)

1. **Workload annotation** - Explicit override on the workload resource
2. **Namespace annotation** - Inherited from the Namespace (when enabled)
3. **Plugin default owner** - Fallback to `kubernetesIngestor.defaultOwner`

## Changes

### Configuration

Added new configuration option `inheritOwnerFromNamespace`:

```yaml
kubernetesIngestor:
  inheritOwnerFromNamespace: false  # Default: false (opt-in)
  defaultOwner: kubernetes-auto-ingested
```

## Usage Example

### Before (repetitive configuration)

```yaml
# Every workload needs the same annotation
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app1
  namespace: team-platform
  annotations:
    terasky.backstage.io/owner: group:default/team-platform
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app2
  namespace: team-platform
  annotations:
    terasky.backstage.io/owner: group:default/team-platform
```

### After (namespace-level configuration)

```yaml
# Set once on the namespace
apiVersion: v1
kind: Namespace
metadata:
  name: team-platform
  annotations:
    terasky.backstage.io/owner: group:default/team-platform
---
# Workloads automatically inherit
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app1
  namespace: team-platform
  # No owner annotation needed - inherits from namespace
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app2
  namespace: team-platform
  # No owner annotation needed - inherits from namespace
```

## Breaking Changes

None. The feature is opt-in and defaults to `false`, maintaining full backward compatibility.
