### PR TITLE
fix(spectrocloud-cluster-provider): handle both error.statusCode and error.code for 404 responses

### DIFF
--- a/plugins/spectrocloud-cluster-provider/src/supplier/SpectroCloudClusterSupplier.ts
+++ b/plugins/spectrocloud-cluster-provider/src/supplier/SpectroCloudClusterSupplier.ts
@@ -302,7 +302,7 @@ export class SpectroCloudClusterSupplier implements KubernetesClustersSupplier {
       try {
         await k8sApi.readNamespace({ name: namespace });
       } catch (error: any) {
-        if (error.statusCode === 404) {
+        if (error.statusCode === 404 || error.code === 404) {
           await k8sApi.createNamespace({ body: { metadata: { name: namespace } } });
         } else if (error.code === 'ETIMEDOUT' || error.code === 'ECONNREFUSED' || error.code === 'EHOSTUNREACH') {
           throw new Error(`Cannot reach cluster ${clusterName}: ${error.code}`);
@@ -315,7 +315,7 @@ export class SpectroCloudClusterSupplier implements KubernetesClustersSupplier {
       try {
         await k8sApi.readNamespacedServiceAccount({ name: serviceAccountName, namespace });
       } catch (error: any) {
-        if (error.statusCode === 404) {
+        if (error.statusCode === 404 || error.code === 404) {
           await k8sApi.createNamespacedServiceAccount({
             namespace,
             body: { metadata: { name: serviceAccountName } },
@@ -329,7 +329,7 @@ export class SpectroCloudClusterSupplier implements KubernetesClustersSupplier {
       try {
         await k8sApi.readNamespacedSecret({ name: secretName, namespace });
       } catch (error: any) {
-        if (error.statusCode === 404) {
+        if (error.statusCode === 404 || error.code === 404) {
           await k8sApi.createNamespacedSecret({
             namespace,
             body: {
@@ -351,7 +351,7 @@ export class SpectroCloudClusterSupplier implements KubernetesClustersSupplier {
       try {
         await rbacApi.readClusterRole({ name: clusterRoleName });
       } catch (error: any) {
-        if (error.statusCode === 404) {
+        if (error.statusCode === 404 || error.code === 404) {
           // Use custom rules if provided, otherwise use default read-only rules
           let rules = clusterRoleRules || [
             {
@@ -382,7 +382,7 @@ export class SpectroCloudClusterSupplier implements KubernetesClustersSupplier {
       try {
         await rbacApi.readClusterRoleBinding({ name: clusterRoleBindingName });
       } catch (error: any) {
-        if (error.statusCode === 404) {
+        if (error.statusCode === 404 || error.code === 404) {
           await rbacApi.createClusterRoleBinding({
             body: {
               metadata: { name: clusterRoleBindingName },


### PR DESCRIPTION
## Summary

The `@kubernetes/client-node` library may return HTTP errors with the status code in either `error.statusCode` or `error.code`, depending on the version and error type.

Previously, the code checked only `error.statusCode === 404`, which caused RBAC setup to throw unhandled errors instead of creating missing resources (namespace, service account, secret, cluster role, and cluster role binding).

This change adds `|| error.code === 404` to all five 404 checks in `setupServiceAccountAccess` to correctly handle both error shapes and ensure missing resources are created as expected.

## Affected resources

- Namespace (`backstage-system`)
- ServiceAccount (`backstage-sa`)
- Secret (`backstage-sa-token`)
- ClusterRole (`backstage-read-only`)
- ClusterRoleBinding (`backstage-read-only-binding`)

## Reproduction

When connecting to SpectroCloud/Palette-managed Kubernetes clusters, the cluster provider fails with:
```
Failed to setup <cluster-name>: HTTP-Code: 404
Message: Unknown API Status Code!
Body: "{...\"message\":\"namespaces \\\"backstage-system\\\" not found\"...}"
```

This happens because the K8s client returns `{ code: 404 }` instead of `{ statusCode: 404 }`, so the 404 is not caught and the resource is never created.