### PR TITLE
Potential fix for code scanning alert no. 26: Incomplete URL substring sanitization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,4 @@ Please reach out if you find any vulnerabilities in these packages and we will t
 
 ## Security Assurance Case
 
-The project's security assurance case — including the threat model, trust boundary analysis, secure design principles, and countermeasures for common implementation weaknesses — is published at:
-
-**https://terasky-oss.github.io/backstage-plugins/security/assurance-case/**
+The project's security assurance case — including the threat model, trust boundary analysis, secure design principles, and countermeasures for common implementation weaknesses — is published [here](./SECURITY_REVIEW.md)

--- a/plugins/ai-rules-plugin-backend/src/service/AgentConfigsService.ts
+++ b/plugins/ai-rules-plugin-backend/src/service/AgentConfigsService.ts
@@ -67,7 +67,17 @@ export class AgentConfigsService {
 
   private async fetchFileContent(gitUrl: string, filePath: string): Promise<string> {
     const cleanGitUrl = gitUrl.replace(/\/+$/, '');
-    const fileUrl = cleanGitUrl.includes('github.com')
+    let isGitHubHost = false;
+
+    try {
+      const parsedUrl = new URL(cleanGitUrl);
+      const hostname = parsedUrl.hostname.toLowerCase();
+      isGitHubHost = hostname === 'github.com' || hostname.endsWith('.github.com');
+    } catch {
+      isGitHubHost = false;
+    }
+
+    const fileUrl = isGitHubHost
       ? `${cleanGitUrl}/raw/main/${filePath}`
       : `${cleanGitUrl}/blob/HEAD/${filePath}`;
 


### PR DESCRIPTION
Potential fix for [https://github.com/TeraSky-OSS/backstage-plugins/security/code-scanning/26](https://github.com/TeraSky-OSS/backstage-plugins/security/code-scanning/26)

Use the built-in `URL` parser and perform host-based checks instead of substring checks on the whole URL string.

Best fix (without changing intended functionality): in `fetchFileContent` (lines around 68–73), parse `cleanGitUrl` with `new URL(cleanGitUrl)`, get `hostname`, normalize to lowercase, and treat it as GitHub only when hostname is exactly `github.com` or a subdomain ending in `.github.com`. Then build `fileUrl` from that boolean. If parsing fails, fall back to non-GitHub behavior (or simply let it be treated as non-GitHub), preserving existing behavior as much as possible while removing unsafe matching.

No new imports or dependencies are required; `URL` is globally available in Node/TypeScript runtime.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
