### PR TITLE
Potential fix for code scanning alert no. 25: Incomplete URL substring sanitization

### DIFF
--- a/plugins/ai-rules-plugin/src/components/AiRulesComponent/AiRulesComponent.tsx
+++ b/plugins/ai-rules-plugin/src/components/AiRulesComponent/AiRulesComponent.tsx
@@ -206,8 +206,19 @@ const manualParseFrontmatter = (content: string) => {
 
 const constructFileUrl = (gitUrl: string, filePath: string): string => {
   const cleanGitUrl = gitUrl.replace(/\/+$/, '');
-  if (cleanGitUrl.includes('github.com')) return `${cleanGitUrl}/blob/main/${filePath}`;
-  if (cleanGitUrl.includes('gitlab.com')) return `${cleanGitUrl}/-/blob/main/${filePath}`;
+
+  try {
+    const host = new URL(cleanGitUrl).hostname.toLowerCase();
+    if (host === 'github.com' || host.endsWith('.github.com')) {
+      return `${cleanGitUrl}/blob/main/${filePath}`;
+    }
+    if (host === 'gitlab.com' || host.endsWith('.gitlab.com')) {
+      return `${cleanGitUrl}/-/blob/main/${filePath}`;
+    }
+  } catch (_e) {
+    // Fallback to default format when URL parsing fails.
+  }
+
   return `${cleanGitUrl}/blob/main/${filePath}`;
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/TeraSky-OSS/backstage-plugins/security/code-scanning/25](https://github.com/TeraSky-OSS/backstage-plugins/security/code-scanning/25)

Use URL parsing and hostname-based checks instead of raw substring checks on the full URL.

Best fix in this file:
- In `plugins/ai-rules-plugin/src/components/AiRulesComponent/AiRulesComponent.tsx`, update `constructFileUrl` to:
  - Normalize trailing slashes as before.
  - Parse the URL with `new URL(cleanGitUrl)` inside `try/catch`.
  - Read `hostname` and match exact host / subdomain-safe patterns:
    - GitHub: `host === 'github.com' || host.endsWith('.github.com')`
    - GitLab: `host === 'gitlab.com' || host.endsWith('.gitlab.com')`
  - Keep fallback behavior unchanged if parse fails or host is neither.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
