### PR TITLE
XRD: add possibility to customize field order in Creation UI

### DIFF
--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -2885,4 +2885,184 @@ describe('XRDTemplateEntityProvider', () => {
       } as any)).resolves.not.toThrow();
     });
   });
+
+  // ── x-ui-order ──────────────────────────────────────────────────────────────
+
+  describe('extractParameters – x-ui-order field ordering', () => {
+    const taskRunner = { run: jest.fn() };
+
+    const makeProvider = () =>
+      new XRDTemplateEntityProvider(
+        taskRunner as any,
+        mockLogger,
+        mockConfig,
+        mockResourceFetcher as any,
+      );
+
+    const makeXrd = (kind = 'MyResource') => ({
+      metadata: { name: `myresources.example.com` },
+      spec: {
+        scope: 'Cluster',
+        names: { kind },
+        group: 'example.com',
+      },
+      clusters: ['test-cluster'],
+    });
+
+    const makeVersion = (specProps: Record<string, any>) => ({
+      name: 'v1alpha1',
+      schema: {
+        openAPIV3Schema: {
+          type: 'object',
+          properties: {
+            spec: {
+              type: 'object',
+              properties: specProps,
+            },
+          },
+        },
+      },
+    });
+
+    it('sorts spec fields by x-ui-order when annotations are present', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        gamma: { type: 'string', 'x-ui-order': 3 },
+        alpha: { type: 'string', 'x-ui-order': 1 },
+        beta:  { type: 'string', 'x-ui-order': 2 },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      // Find the spec parameters group (title: 'Resource Spec')
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup).toBeDefined();
+
+      const keys = Object.keys(specGroup.properties);
+      expect(keys.indexOf('alpha')).toBeLessThan(keys.indexOf('beta'));
+      expect(keys.indexOf('beta')).toBeLessThan(keys.indexOf('gamma'));
+    });
+
+    it('places fields without x-ui-order at the end, sorted alphabetically', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        zebra:   { type: 'string' },
+        one:     { type: 'string', 'x-ui-order': 1 },
+        ant:     { type: 'string' },
+        two:     { type: 'string', 'x-ui-order': 2 },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const keys = Object.keys(specGroup.properties);
+
+      // x-ui-order fields come first
+      expect(keys.indexOf('one')).toBeLessThan(keys.indexOf('ant'));
+      expect(keys.indexOf('two')).toBeLessThan(keys.indexOf('ant'));
+      // unordered fields are alphabetical: ant < zebra
+      expect(keys.indexOf('ant')).toBeLessThan(keys.indexOf('zebra'));
+    });
+
+    it('preserves original insertion order when no x-ui-order is used', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        charlie: { type: 'string' },
+        alice:   { type: 'string' },
+        bob:     { type: 'string' },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      // no x-ui-order → no reordering, original object order is preserved
+      expect(Object.keys(specGroup.properties)).toEqual(['charlie', 'alice', 'bob']);
+    });
+
+    it('sets ui:order on array items whose properties carry x-ui-order', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        ports: {
+          type: 'array',
+          'x-ui-order': 1,
+          items: {
+            type: 'object',
+            properties: {
+              protocol:    { type: 'string', 'x-ui-order': 3 },
+              publicPort:  { type: 'integer', 'x-ui-order': 1 },
+              privatePort: { type: 'integer', 'x-ui-order': 2 },
+            },
+          },
+        },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const portsField = specGroup.properties.ports;
+
+      expect(portsField.items['ui:order']).toEqual(['publicPort', 'privatePort', 'protocol', '*']);
+    });
+
+    it('sets ui:order on object fields whose properties carry x-ui-order', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        disk: {
+          type: 'object',
+          'x-ui-order': 1,
+          properties: {
+            format: { type: 'string', 'x-ui-order': 2 },
+            size:   { type: 'integer', 'x-ui-order': 1 },
+          },
+        },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const diskField = specGroup.properties.disk;
+
+      expect(diskField['ui:order']).toEqual(['size', 'format', '*']);
+    });
+
+    it('does not set ui:order on nested fields without x-ui-order', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        ports: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              protocol:   { type: 'string' },
+              publicPort: { type: 'integer' },
+            },
+          },
+        },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.ports.items['ui:order']).toBeUndefined();
+    });
+
+    it('applies ui:order recursively to deeply nested object properties', () => {
+      const provider = makeProvider();
+      const version = makeVersion({
+        config: {
+          type: 'object',
+          'x-ui-order': 1,
+          properties: {
+            network: {
+              type: 'object',
+              properties: {
+                dns:     { type: 'string', 'x-ui-order': 2 },
+                gateway: { type: 'string', 'x-ui-order': 1 },
+              },
+            },
+          },
+        },
+      });
+
+      const params = (provider as any).extractParameters(version, ['test-cluster'], makeXrd());
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const networkField = specGroup.properties.config.properties.network;
+
+      expect(networkField['ui:order']).toEqual(['gateway', 'dns', '*']);
+    });
+  });
 });

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -796,9 +796,46 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       }
       return processedProperties;
     };
-    const processedSpec = version.schema?.openAPIV3Schema?.properties?.spec
+
+    const rawSpec = version.schema?.openAPIV3Schema?.properties?.spec
       ? processProperties(version.schema.openAPIV3Schema.properties.spec.properties)
       : {};
+
+    // Sort spec fields by x-ui-order annotation when present.
+    // Fields with x-ui-order are placed first (ascending), fields without it
+    // are appended at the end sorted alphabetically.
+    const sortSpecByXUiOrder = (spec: Record<string, any>): Record<string, any> => {
+      const withOrder = Object.entries(spec).filter(([, v]) => typeof v['x-ui-order'] === 'number');
+      const withoutOrder = Object.entries(spec).filter(([, v]) => typeof v['x-ui-order'] !== 'number');
+      withOrder.sort((a, b) => (a[1]['x-ui-order'] as number) - (b[1]['x-ui-order'] as number));
+      withoutOrder.sort((a, b) => a[0].localeCompare(b[0]));
+      return Object.fromEntries([...withOrder, ...withoutOrder]);
+    };
+
+    const hasXUiOrder = Object.values(rawSpec).some(v => typeof v['x-ui-order'] === 'number');
+    const processedSpec = hasXUiOrder ? sortSpecByXUiOrder(rawSpec) : rawSpec;
+
+    // Recursively inject ui:order into object/array schemas whose immediate
+    // child properties carry x-ui-order annotations.
+    const applyNestedUiOrder = (schema: Record<string, any>): void => {
+      if (schema.type === 'object' && schema.properties) {
+        const ordered = Object.entries(schema.properties)
+          .filter(([, v]) => typeof (v as any)['x-ui-order'] === 'number')
+          .sort((a, b) => (a[1] as any)['x-ui-order'] - (b[1] as any)['x-ui-order']);
+        if (ordered.length > 0) {
+          schema['ui:order'] = [...ordered.map(([key]) => key), '*'];
+        }
+        Object.values(schema.properties).forEach(child =>
+          applyNestedUiOrder(child as Record<string, any>),
+        );
+      } else if (schema.type === 'array' && schema.items) {
+        applyNestedUiOrder(schema.items as Record<string, any>);
+      }
+    };
+    Object.values(processedSpec).forEach(field =>
+      applyNestedUiOrder(field as Record<string, any>),
+    );
+
     const additionalParameters = {
       title: 'Resource Spec',
       properties: processedSpec,

--- a/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-order.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-order.md
@@ -1,0 +1,239 @@
+# XRD Field Ordering with `x-ui-order`
+
+The `kubernetes-ingestor` plugin supports the `x-ui-order` vendor extension on XRD spec fields.
+When present, the plugin uses these annotations to control the order in which fields appear in
+the generated Backstage scaffolder template.
+
+## How it works
+
+During template generation the plugin processes every XRD version's `openAPIV3Schema`.
+For the top-level `spec` properties it applies the following rules:
+
+1. Fields that carry an `x-ui-order: <number>` annotation are placed **first**, sorted in
+   ascending numeric order.
+2. Fields **without** `x-ui-order` are appended **after** the ordered fields, sorted
+   alphabetically by key name.
+3. If **no** field in a spec carries `x-ui-order`, the original schema order is preserved
+   unchanged.
+
+For nested fields (array items and inline objects) the plugin generates a
+[`ui:order`](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema/#uiorder)
+array in the `uiSchema` so the Backstage form renderer respects the intended order:
+
+- `array` field → `items['ui:order']` is set to `[...orderedKeys, '*']`
+- `object` field → `field['ui:order']` is set to `[...orderedKeys, '*']`
+
+The trailing `'*'` wildcard ensures any extra field not listed explicitly is still rendered.
+
+---
+
+## Example XRD
+
+Below is a trimmed `CompositeResourceDefinition` for a generic compute deployment that
+demonstrates `x-ui-order` on both top-level spec fields and nested array-item properties.
+
+```yaml
+---
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    terasky.backstage.io/add-to-catalog: "true"
+  name: commoncustomdeployments.infra.example.com
+spec:
+  group: infra.example.com
+  scope: Cluster
+  names:
+    kind: CommonCustomDeployment
+    plural: commoncustomdeployments
+    shortNames:
+      - ccd
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              description: Desired state of CommonCustomDeployment.
+              properties:
+
+                # ── ordered top-level fields ──────────────────────────────────
+                stateful:
+                  type: boolean
+                  x-ui-order: 1
+                  default: false
+                  description: Stateful naming mode. Upgrade rollout is disabled when true.
+
+                replicas:
+                  type: integer
+                  x-ui-order: 2
+                  default: 1
+                  description: Number of base machine replicas.
+
+                os:
+                  type: string
+                  x-ui-order: 3
+                  description: Base operating-system image key.
+
+                size:
+                  type: string
+                  x-ui-order: 4
+                  description: Instance size / service offering.
+                  enum:
+                    - vm.xs
+                    - vm.s
+                    - vm.m
+                    - vm.l
+                    - vm.xl
+
+                network:
+                  type: string
+                  x-ui-order: 5
+                  default: k8s
+                  description: Network key from environment map.
+                  enum:
+                    - k8s
+                    - app
+
+                exposureType:
+                  type: string
+                  x-ui-order: 6
+                  default: None
+                  description: Exposure type for service ports.
+                  enum:
+                    - LoadBalancer
+                    - None
+
+                affinity:
+                  type: string
+                  x-ui-order: 7
+                  default: None
+                  description: Scheduling affinity rule.
+                  enum:
+                    - host anti-affinity
+                    - host affinity
+                    - None
+
+                disks:
+                  type: array
+                  x-ui-order: 8
+                  description: List of additional data disks.
+                  items:
+                    type: object
+                    required:
+                      - size
+                      - name
+                    properties:
+                      name:
+                        type: string
+                      size:
+                        type: integer
+
+                additionalNICNetworks:
+                  type: array
+                  x-ui-order: 9
+                  description: Additional NIC networks (max 2).
+                  default: []
+                  maxItems: 2
+                  items:
+                    type: string
+                    enum:
+                      - ingress
+                      - egress
+
+                # ── nested x-ui-order on array items ─────────────────────────
+                ports:
+                  type: array
+                  x-ui-order: 10
+                  description: Ports exposed via load balancer rules.
+                  items:
+                    type: object
+                    properties:
+                      publicPort:
+                        type: integer
+                        x-ui-order: 1
+                        description: Exposed public VIP port.
+                      privatePort:
+                        type: integer
+                        x-ui-order: 2
+                        description: Target port on instance.
+                      protocol:
+                        type: string
+                        x-ui-order: 3
+                        description: L4 protocol for port forwarding.
+                        enum:
+                          - tcp
+                          - udp
+
+                # ── field without x-ui-order (appended alphabetically) ────────
+                tags:
+                  type: array
+                  description: Arbitrary string tags for grouping.
+                  items:
+                    type: string
+```
+
+### What the plugin generates
+
+Given the XRD above the plugin produces the following for the `Resource Spec` step of the
+scaffolder template:
+
+| Position | Field | Reason |
+|---|---|---|
+| 1 | `stateful` | `x-ui-order: 1` |
+| 2 | `replicas` | `x-ui-order: 2` |
+| 3 | `os` | `x-ui-order: 3` |
+| 4 | `size` | `x-ui-order: 4` |
+| 5 | `network` | `x-ui-order: 5` |
+| 6 | `exposureType` | `x-ui-order: 6` |
+| 7 | `affinity` | `x-ui-order: 7` |
+| 8 | `disks` | `x-ui-order: 8` |
+| 9 | `additionalNICNetworks` | `x-ui-order: 9` |
+| 10 | `ports` | `x-ui-order: 10` |
+| 11 | `tags` | no `x-ui-order` → appended alphabetically |
+
+For the `ports` array the plugin also injects `ui:order` into the array-item schema:
+
+```json
+"ports": {
+  "type": "array",
+  "items": {
+    "ui:order": ["publicPort", "privatePort", "protocol", "*"]
+  }
+}
+```
+
+This causes the scaffolder form to render each port row with the columns in the intended
+order instead of the schema-declaration order.
+
+---
+
+## Rules summary
+
+| Scenario | Behaviour |
+|---|---|
+| All spec fields have `x-ui-order` | Sorted ascending by value |
+| Mix of ordered and unordered fields | Ordered first, then unordered alphabetically |
+| No spec field has `x-ui-order` | Original schema order preserved |
+| Array item properties have `x-ui-order` | `items['ui:order']` array injected |
+| Object properties have `x-ui-order` | `field['ui:order']` array injected |
+| Nested fields have no `x-ui-order` | No `ui:order` injected, schema order used |
+
+---
+
+## Notes
+
+- `x-ui-order` must be a **number** (integer or float). String values are ignored.
+- The feature only applies to the `spec` object of the XRD schema. Other top-level properties
+  (`status`, `metadata`, etc.) are not affected.
+- The trailing `'*'` wildcard in generated `ui:order` arrays ensures fields added to the CRD
+  after template generation are still rendered in the form.
+- `x-ui-order` is a vendor extension and is **not** part of the Kubernetes CRD validation;
+  it is stripped from the CRD by the API server and only used at template-generation time by
+  this plugin.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
               - About: plugins/kubernetes-ingestor/backend/about.md
               - Install: plugins/kubernetes-ingestor/backend/install.md
               - Configure: plugins/kubernetes-ingestor/backend/configure.md
+              - XRD Field Ordering (x-ui-order): plugins/kubernetes-ingestor/backend/xrd-ui-order.md
       - Crossplane:
           - Overview: plugins/crossplane/overview.md
           - Backend:


### PR DESCRIPTION
Add x-ui-order support for XRD template field orderingʼ

What
The kubernetes-ingestor plugin now respects the x-ui-order vendor extension on XRD spec properties when generating Backstage scaffolder templates.

Behaviour
Fields with x-ui-order: <number> are placed first, sorted ascending
Fields without x-ui-order are appended alphabetically after ordered fields
If no field carries x-ui-order, original schema order is preserved
For array items and object fields whose nested properties carry x-ui-order, a ui:order array is injected so the scaffolder form renders columns in the correct order

Changes
EntityProvider.ts — sorting logic in extractParameters + ui:order injection for nested fields
EntityProvider.test.ts — 6 new unit tests covering all ordering scenarios
site/docs/…/xrd-ui-order.md — documentation with full XRD example and rules summar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `x-ui-order` to control top-level and nested field ordering in generated forms; ordered fields appear first (ascending), unordered fields follow (alphabetically), and original order is preserved when no orders are present. Injected UI ordering ensures explicitly ordered keys render before others.

* **Documentation**
  * Added a guide describing `x-ui-order` behavior and examples for the Kubernetes Ingestor plugin.

* **Tests**
  * Added tests covering top-level, nested, recursive ordering and wildcard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->