### PR TITLE
feat(kubernetes-ingestor): re-export DefaultKubernetesResourceFetcher from public entry

### DIFF
--- a/plugins/kubernetes-ingestor/src/index.ts
+++ b/plugins/kubernetes-ingestor/src/index.ts
@@ -1,4 +1,5 @@
 export { catalogModuleKubernetesIngestor as default } from './module';
 export { KubernetesEntityProvider, XRDTemplateEntityProvider } from './providers';
 export type { DeltaEvent } from './providers';
+export { DefaultKubernetesResourceFetcher } from './services';
 export type { KubernetesResourceFetcher, KubernetesResourceFetcherOptions } from './types';


### PR DESCRIPTION
## Summary

The `services/index.ts` barrel already exports `DefaultKubernetesResourceFetcher`, but `plugins/kubernetes-ingestor/src/index.ts` (the package's public entry) does not re-export it. This adds that one line.

## Why

Downstream consumers want to construct `KubernetesEntityProvider` / `XRDTemplateEntityProvider` themselves (for example, to hold a reference to the provider so they can call `deltaUpdate()` from a custom event subscriber). Both constructors require a `DefaultKubernetesResourceFetcher` instance, but because the class isn't reachable through the package's public entry, callers have to deep-import from `dist/services/KubernetesResourceFetcher.cjs.js` and add an ambient `declare module` shim to type it. Exporting it from `src/index.ts` removes that workaround.

## Change

```ts
// plugins/kubernetes-ingestor/src/index.ts
+ export { DefaultKubernetesResourceFetcher } from './services';
```

No behavior change — this just makes an existing class reachable through the documented entry point.

## Test plan

- [x] `./services` already exports the symbol (no new internals added).
- [ ] `yarn build` in `plugins/kubernetes-ingestor` produces the class in `dist/index.d.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the public exports for the Kubernetes ingester service module. This change adjusts which symbols are exposed by the module; it is an internal API maintenance update and does not alter user-facing functionality or UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->