### PR TITLE
feat(kubernetes-ingestor): optional events-bus subscription for incremental updates

### DIFF
--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -52,6 +52,20 @@ export interface Config {
      */
     allowedClusterNames?: string[];
     /**
+     * Optional incremental-update subscription. When configured, the module
+     * subscribes to this topic on the Backstage events bus and applies each
+     * event as a delta against the provider without waiting for the next
+     * periodic full sync. Downstream integrations are responsible for
+     * publishing events in the documented payload shape:
+     * `{ action: 'upsert' | 'delete', apiVersion, kind, name, namespace?, clusterName }`.
+     */
+    events?: {
+      /**
+       * Name of the events-bus topic to subscribe to.
+       */
+      topic?: string;
+    };
+    /**
      * Cluster name mapping for entity annotations
      * Maps backend cluster names (used for ingestion) to frontend cluster names (used in kubernetes-cluster annotations)
      * Supports both prefix-based replacement and explicit mappings

--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -57,11 +57,13 @@ export interface Config {
      * event as a delta against the provider without waiting for the next
      * periodic full sync. Downstream integrations are responsible for
      * publishing events in the documented payload shape:
-     * `{ action: 'upsert' | 'delete', apiVersion, kind, name, namespace?, clusterName }`.
+     * `{ action: 'upsert' | 'delete', apiVersion, kind, name, namespace?, clusterName, entityNames? }`.
+     * @visibility backend
      */
     events?: {
       /**
        * Name of the events-bus topic to subscribe to.
+       * @visibility backend
        */
       topic?: string;
     };

--- a/plugins/kubernetes-ingestor/package.json
+++ b/plugins/kubernetes-ingestor/package.json
@@ -40,6 +40,7 @@
     "@backstage/config": "^1.3.7",
     "@backstage/plugin-catalog-import": "^0.13.12",
     "@backstage/plugin-catalog-node": "^2.2.0",
+    "@backstage/plugin-events-node": "^0.4.21",
     "@backstage/plugin-kubernetes": "^0.12.18",
     "@backstage/plugin-kubernetes-backend": "^0.21.3",
     "@backstage/plugin-kubernetes-common": "^0.9.11",

--- a/plugins/kubernetes-ingestor/src/module.ts
+++ b/plugins/kubernetes-ingestor/src/module.ts
@@ -16,21 +16,30 @@ interface DeltaEventPayload {
   name: string;
   namespace?: string;
   clusterName: string;
+  entityNames?: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function parseEntityNames(value: unknown): string[] | undefined | null {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some(v => typeof v !== 'string')) return null;
+  return value as string[];
+}
+
 function parseDeltaEventPayload(payload: unknown): DeltaEventPayload | undefined {
   if (!isRecord(payload)) return undefined;
-  const { action, apiVersion, kind, name, namespace, clusterName } = payload;
+  const { action, apiVersion, kind, name, namespace, clusterName, entityNames } = payload;
   if (action !== 'upsert' && action !== 'delete') return undefined;
   if (typeof apiVersion !== 'string' || apiVersion.length === 0) return undefined;
   if (typeof kind !== 'string' || kind.length === 0) return undefined;
   if (typeof name !== 'string' || name.length === 0) return undefined;
   if (typeof clusterName !== 'string' || clusterName.length === 0) return undefined;
   if (namespace !== undefined && typeof namespace !== 'string') return undefined;
+  const parsedEntityNames = parseEntityNames(entityNames);
+  if (parsedEntityNames === null) return undefined;
   return {
     action,
     apiVersion,
@@ -38,8 +47,11 @@ function parseDeltaEventPayload(payload: unknown): DeltaEventPayload | undefined
     name,
     namespace: namespace === '' ? undefined : namespace,
     clusterName,
+    entityNames: parsedEntityNames,
   };
 }
+
+const FULL_SYNC_NOT_READY_MESSAGE = 'initial full sync has not completed';
 
 export const catalogModuleKubernetesIngestor = createBackendModule({
   pluginId: 'catalog',
@@ -150,12 +162,19 @@ export const catalogModuleKubernetesIngestor = createBackendModule({
               try {
                 await templateEntityProvider.deltaUpdate(deltaEvent);
               } catch (error) {
-                logger.warn('Failed to apply kubernetes-ingestor delta event', {
+                const message = error instanceof Error ? error.message : String(error);
+                // Events that arrive before the initial full sync completes
+                // are expected during startup; log them at debug to avoid
+                // noise and let the next full sync reconcile.
+                const level = message.includes(FULL_SYNC_NOT_READY_MESSAGE)
+                  ? 'debug'
+                  : 'warn';
+                logger[level]('Failed to apply kubernetes-ingestor delta event', {
                   topic: params.topic,
                   clusterName: deltaEvent.clusterName,
                   kind: deltaEvent.kind,
                   name: deltaEvent.name,
-                  error: error instanceof Error ? error.message : String(error),
+                  error: message,
                 });
               }
             },

--- a/plugins/kubernetes-ingestor/src/module.ts
+++ b/plugins/kubernetes-ingestor/src/module.ts
@@ -5,8 +5,41 @@ import {
 import {
   catalogProcessingExtensionPoint,
 } from '@backstage/plugin-catalog-node';
+import { EventParams, eventsServiceRef } from '@backstage/plugin-events-node';
 import { KubernetesEntityProvider, RGDTemplateEntityProvider, XRDTemplateEntityProvider } from './providers';
 import { DefaultKubernetesResourceFetcher } from './services';
+
+interface DeltaEventPayload {
+  action: 'upsert' | 'delete';
+  apiVersion: string;
+  kind: string;
+  name: string;
+  namespace?: string;
+  clusterName: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseDeltaEventPayload(payload: unknown): DeltaEventPayload | undefined {
+  if (!isRecord(payload)) return undefined;
+  const { action, apiVersion, kind, name, namespace, clusterName } = payload;
+  if (action !== 'upsert' && action !== 'delete') return undefined;
+  if (typeof apiVersion !== 'string' || apiVersion.length === 0) return undefined;
+  if (typeof kind !== 'string' || kind.length === 0) return undefined;
+  if (typeof name !== 'string' || name.length === 0) return undefined;
+  if (typeof clusterName !== 'string' || clusterName.length === 0) return undefined;
+  if (namespace !== undefined && typeof namespace !== 'string') return undefined;
+  return {
+    action,
+    apiVersion,
+    kind,
+    name,
+    namespace: namespace === '' ? undefined : namespace,
+    clusterName,
+  };
+}
 
 export const catalogModuleKubernetesIngestor = createBackendModule({
   pluginId: 'catalog',
@@ -21,6 +54,7 @@ export const catalogModuleKubernetesIngestor = createBackendModule({
         scheduler: coreServices.scheduler,
         auth: coreServices.auth,
         urlReader: coreServices.urlReader,
+        events: eventsServiceRef,
       },
       async init({
         catalog,
@@ -30,6 +64,7 @@ export const catalogModuleKubernetesIngestor = createBackendModule({
         scheduler,
         auth,
         urlReader,
+        events,
       }) {
         const taskRunner = scheduler.createScheduledTaskRunner({
           frequency: {
@@ -92,6 +127,42 @@ export const catalogModuleKubernetesIngestor = createBackendModule({
         // Only disable if explicitly set to false; default is enabled
         if (xrdEnabled !== false) {
           await catalog.addEntityProvider(xrdTemplateEntityProvider);
+        }
+
+        // Optional incremental-update subscription. When `kubernetesIngestor.events.topic`
+        // is configured, the module subscribes to the topic on the Backstage events bus
+        // and applies each event as a delta against the provider, without waiting for
+        // the next periodic full sync. Downstream integrations are responsible for
+        // publishing events in the documented payload shape.
+        const deltaTopic = config.getOptionalString('kubernetesIngestor.events.topic');
+        if (deltaTopic) {
+          await events.subscribe({
+            id: 'kubernetes-ingestor-delta',
+            topics: [deltaTopic],
+            onEvent: async (params: EventParams) => {
+              const deltaEvent = parseDeltaEventPayload(params.eventPayload);
+              if (!deltaEvent) {
+                logger.debug('Dropping malformed kubernetes-ingestor delta event', {
+                  topic: params.topic,
+                });
+                return;
+              }
+              try {
+                await templateEntityProvider.deltaUpdate(deltaEvent);
+              } catch (error) {
+                logger.warn('Failed to apply kubernetes-ingestor delta event', {
+                  topic: params.topic,
+                  clusterName: deltaEvent.clusterName,
+                  kind: deltaEvent.kind,
+                  name: deltaEvent.name,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            },
+          });
+          logger.info('Kubernetes ingestor subscribed to delta events', {
+            topic: deltaTopic,
+          });
         }
       },
     });


### PR DESCRIPTION
## Summary

Teaches the default `catalogModuleKubernetesIngestor` to optionally subscribe to a Backstage events-bus topic and call `KubernetesEntityProvider.deltaUpdate(...)` for each validated payload. When the new config key is not set, behavior is unchanged.

This lets downstream integrations land catalog mutations in near-real-time without having to reconstruct the providers themselves just to hold a reference for `deltaUpdate()`.

## Why

`KubernetesEntityProvider.deltaUpdate()` has shipped since v3.14.0 as a primitive, but the default module does not expose the provider reference and does not subscribe to any events. The only way today to drive `deltaUpdate()` from an event stream is to *replace* the default module with a fork that constructs the providers itself and holds the reference — which is a lot of boilerplate to duplicate upstream internals (task runners, fetcher construction, XRD/RGD gating, etc.) just to add the subscription.

This PR moves the subscription into the default module behind an opt-in config, so downstream consumers only need to publish events onto the events bus.

## Config

```yaml
kubernetesIngestor:
  events:
    topic: kubernetes-ingestor.delta  # any events-bus topic
```

Expected payload shape on the topic:

```ts
{
  action: 'upsert' | 'delete',
  apiVersion: string,
  kind: string,
  name: string,
  namespace?: string,   // omit or '' for cluster-scoped
  clusterName: string,  // Backstage cluster name
}
```

Malformed payloads are dropped at `debug` level. Errors from `deltaUpdate()` are logged at `warn` and swallowed so a bad event does not stall the subscriber.

The upstream module intentionally does not parse cluster-discovery-specific payloads (EKS ARNs, GKE project/zone tuples, etc.) — downstream integrations translate their native event shape into the above before publishing. This keeps the module source-agnostic.

## Changes

- `src/module.ts`: add `events: eventsServiceRef` to deps, subscribe to the configured topic if set, route each validated event into `templateEntityProvider.deltaUpdate(...)`.
- `config.d.ts`: document the new `kubernetesIngestor.events.topic` key.
- `package.json`: add `@backstage/plugin-events-node` as a runtime dependency.

No changes to providers, services, or the XRD/RGD gating.

## Test plan

- [x] `src/module.ts` compiles under the plugin's own `tsc` (local build).
- [ ] `yarn test --workspace @terasky/backstage-plugin-kubernetes-ingestor` — existing tests still pass (the module is still defined and still has `$$type === '@backstage/BackendFeature'`).
- [ ] End-to-end in a consumer backend: configure `kubernetesIngestor.events.topic` and an events-bus publisher on the same topic; confirm that emitted `{ action: 'upsert', ... }` events produce catalog entities without waiting for the 10-minute full sync.
- [ ] Omit the config key: backend boots and only the periodic full sync runs (prior behavior).

## Backwards compatibility

100% backwards compatible — the new behavior is gated on an optional config key that previously had no meaning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional event-subscription support to the Kubernetes ingestor for incremental entity upserts and deletes. Configurable event topic, input validation, and robust error handling ensure malformed events are ignored and processing issues are logged.

* **Chores**
  * Updated runtime dependency list and applied minor formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->