### PR TITLE
Extend xrd template schema to XRD Creation window, add x-ui-hidden an…

### DIFF
--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3065,4 +3065,249 @@ describe('XRDTemplateEntityProvider', () => {
       expect(networkField['ui:order']).toEqual(['gateway', 'dns', '*']);
     });
   });
+
+  // ── x-ui-hidden ─────────────────────────────────────────────────────────
+
+  describe('extractParameters – x-ui-hidden field filtering', () => {
+    const taskRunner = { run: jest.fn() };
+
+    const makeProvider = () =>
+      new XRDTemplateEntityProvider(
+        taskRunner as any,
+        mockLogger,
+        mockConfig,
+        mockResourceFetcher as any,
+      );
+
+    const makeXrd = (kind = 'MyResource') => ({
+      metadata: { name: 'myresources.example.com' },
+      spec: {
+        scope: 'Cluster',
+        names: { kind },
+        group: 'example.com',
+      },
+      clusters: ['test-cluster'],
+    });
+
+    const makeVersion = (specProps: Record<string, any>) => ({
+      name: 'v1alpha1',
+      schema: {
+        openAPIV3Schema: {
+          type: 'object',
+          properties: {
+            spec: { type: 'object', properties: specProps },
+          },
+        },
+      },
+    });
+
+    it('excludes fields marked with x-ui-hidden: true from the form schema', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          visible: { type: 'string' },
+          hidden:  { type: 'string', 'x-ui-hidden': true },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.visible).toBeDefined();
+      expect(specGroup.properties.hidden).toBeUndefined();
+    });
+
+    it('excludes nested object fields marked with x-ui-hidden: true', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          config: {
+            type: 'object',
+            properties: {
+              public:   { type: 'string' },
+              internal: { type: 'string', 'x-ui-hidden': true },
+            },
+          },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.config.properties.public).toBeDefined();
+      expect(specGroup.properties.config.properties.internal).toBeUndefined();
+    });
+
+    it('does NOT require deprecated: true — x-ui-hidden works independently', () => {
+      // x-ui-hidden is for fields being migrated or that should be hidden from
+      // users without being marked deprecated in the XRD schema.
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          migrating:        { type: 'string', 'x-ui-hidden': true },
+          deprecatedHidden: { type: 'string', 'x-ui-hidden': true, deprecated: true },
+          notHidden:        { type: 'string' },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.migrating).toBeUndefined();
+      expect(specGroup.properties.deprecatedHidden).toBeUndefined();
+      expect(specGroup.properties.notHidden).toBeDefined();
+    });
+  });
+
+  // ── x-ui-advanced ───────────────────────────────────────────────────────
+
+  describe('extractParameters – x-ui-advanced field grouping', () => {
+    const taskRunner = { run: jest.fn() };
+
+    const makeProvider = () =>
+      new XRDTemplateEntityProvider(
+        taskRunner as any,
+        mockLogger,
+        mockConfig,
+        mockResourceFetcher as any,
+      );
+
+    const makeXrd = (kind = 'MyResource') => ({
+      metadata: { name: 'myresources.example.com' },
+      spec: {
+        scope: 'Cluster',
+        names: { kind },
+        group: 'example.com',
+      },
+      clusters: ['test-cluster'],
+    });
+
+    const makeVersion = (specProps: Record<string, any>) => ({
+      name: 'v1alpha1',
+      schema: {
+        openAPIV3Schema: {
+          type: 'object',
+          properties: {
+            spec: { type: 'object', properties: specProps },
+          },
+        },
+      },
+    });
+
+    it('moves x-ui-advanced fields into showAdvancedSettings dependency', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          primary:  { type: 'string' },
+          advanced: { type: 'string', 'x-ui-advanced': true },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.primary).toBeDefined();
+      expect(specGroup.properties.advanced).toBeUndefined();
+      expect(specGroup.properties.showAdvancedSettings).toBeDefined();
+      expect(specGroup.properties.showAdvancedSettings.type).toBe('boolean');
+      expect(specGroup.properties.showAdvancedSettings.default).toBe(false);
+      const dep = specGroup.dependencies?.showAdvancedSettings;
+      expect(dep).toBeDefined();
+      expect(dep.then.properties.advanced).toBeDefined();
+    });
+
+    it('converts non-boolean defaults to ui:placeholder for advanced fields', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          timeout: { type: 'string', default: '30s', 'x-ui-advanced': true },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const dep = specGroup.dependencies?.showAdvancedSettings;
+      expect(dep.then.properties.timeout['ui:placeholder']).toBe('30s');
+      expect(dep.then.properties.timeout.default).toBeUndefined();
+    });
+
+    it('removes boolean defaults without adding ui:placeholder for advanced fields', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          debug: { type: 'boolean', default: false, 'x-ui-advanced': true },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const dep = specGroup.dependencies?.showAdvancedSettings;
+      expect(dep.then.properties.debug['ui:placeholder']).toBeUndefined();
+      expect(dep.then.properties.debug.default).toBeUndefined();
+    });
+
+    it('strips x-ui-advanced marker from the moved field', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          opt: { type: 'string', 'x-ui-advanced': true },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const dep = specGroup.dependencies?.showAdvancedSettings;
+      expect(dep.then.properties.opt['x-ui-advanced']).toBeUndefined();
+    });
+
+    it('does not add showAdvancedSettings when no advanced fields exist', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          simple: { type: 'string' },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      expect(specGroup.properties.showAdvancedSettings).toBeUndefined();
+      expect(specGroup.dependencies).toEqual({});
+    });
+
+    it('sorts x-ui-advanced fields by x-ui-order within the dependency section', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          affinity:  { type: 'string', 'x-ui-advanced': true, 'x-ui-order': 7, default: 'None' },
+          statefull: { type: 'boolean', 'x-ui-advanced': true, 'x-ui-order': 1, default: false },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const dep = specGroup.dependencies?.showAdvancedSettings;
+      const keys = Object.keys(dep.then.properties);
+      // statefull (x-ui-order: 1) must appear before affinity (x-ui-order: 7)
+      expect(keys.indexOf('statefull')).toBeLessThan(keys.indexOf('affinity'));
+    });
+
+    it('propagates nested object advanced fields into sub-dependencies', () => {
+      const provider = makeProvider();
+      const params = (provider as any).extractParameters(
+        makeVersion({
+          networking: {
+            type: 'object',
+            properties: {
+              mode: { type: 'string' },
+              mtu:  { type: 'integer', default: 1500, 'x-ui-advanced': true },
+            },
+          },
+        }),
+        ['test-cluster'],
+        makeXrd(),
+      );
+      const specGroup = params.find((p: any) => p.title === 'Resource Spec');
+      const net = specGroup.properties.networking;
+      expect(net.properties.mode).toBeDefined();
+      expect(net.properties.mtu).toBeUndefined();
+      expect(net.dependencies?.showAdvancedSettings).toBeDefined();
+      expect(net.dependencies.showAdvancedSettings.then.properties.mtu['ui:placeholder']).toBe('1500');
+    });
+  });
 });

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -751,11 +751,17 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     };
     // Additional parameters
     const convertDefaultValuesToPlaceholders = this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.convertDefaultValuesToPlaceholders');
-    const processProperties = (properties: Record<string, any>): Record<string, any> => {
+    const processProperties = (properties: Record<string, any>): { properties: Record<string, any>; dependencies: Record<string, any> } => {
       const processedProperties: Record<string, any> = {};
+      const generatedDependencies: Record<string, any> = {};
+
       for (const [key, value] of Object.entries(properties)) {
         const typedValue = value as Record<string, any>;
-        
+
+        if (typedValue['x-ui-hidden'] === true) {
+          continue;
+        }
+
         // Handle fields with x-kubernetes-preserve-unknown-fields: true
         if (typedValue['x-kubernetes-preserve-unknown-fields'] === true && !typedValue.type) {
           processedProperties[key] = {
@@ -767,11 +773,19 @@ export class XRDTemplateEntityProvider implements EntityProvider {
             },
           };
         } else if (typedValue.type === 'object' && typedValue.properties) {
-          const subProperties = processProperties(typedValue.properties);
-          processedProperties[key] = { ...typedValue, properties: subProperties };
+          const { properties: subProps, dependencies: subDeps } = processProperties(typedValue.properties);
+          processedProperties[key] = {
+            ...typedValue,
+            properties: subProps,
+            dependencies: {
+              ...typedValue.dependencies,
+              ...subDeps,
+            },
+          };
           if (typedValue.properties.enabled && typedValue.properties.enabled.type === 'boolean') {
             const siblingKeys = Object.keys(typedValue.properties).filter(k => k !== 'enabled');
             processedProperties[key].dependencies = {
+              ...processedProperties[key].dependencies,
               enabled: {
                 if: {
                   properties: {
@@ -794,12 +808,76 @@ export class XRDTemplateEntityProvider implements EntityProvider {
           }
         }
       }
-      return processedProperties;
+
+      // Group x-ui-advanced fields under a togglable "Show Advanced Settings" section.
+      // RJSF auto-populates defaults for all fields with `default`; moving advanced fields
+      // into a conditional dependency with defaults stripped prevents them from appearing
+      // in every generated manifest when the user never touched those fields.
+      const finalProperties: Record<string, any> = {};
+      const advancedProperties: Record<string, any> = {};
+
+      for (const [key, value] of Object.entries(processedProperties)) {
+        if (value['x-ui-advanced'] === true) {
+          const advancedValue = { ...value };
+          delete advancedValue['x-ui-advanced'];
+
+          if (advancedValue.type === 'object' && advancedValue.properties) {
+            const removeDefaults = (props: Record<string, any>) => {
+              Object.values(props).forEach((p: any) => {
+                if (p.default !== undefined) {
+                  if (p.type !== 'boolean') p['ui:placeholder'] = String(p.default);
+                  delete p.default;
+                }
+                if (p.type === 'object' && p.properties) removeDefaults(p.properties);
+              });
+            };
+            removeDefaults(advancedValue.properties);
+          } else if (advancedValue.default !== undefined) {
+            if (advancedValue.type !== 'boolean') {
+              advancedValue['ui:placeholder'] = String(advancedValue.default);
+            }
+            delete advancedValue.default;
+          }
+
+          advancedProperties[key] = advancedValue;
+        } else {
+          finalProperties[key] = value;
+        }
+      }
+
+      if (Object.keys(advancedProperties).length > 0) {
+        // Sort advanced fields by x-ui-order so the dependency section respects
+        // the same ordering intent as the main form fields.
+        const advWithOrder = Object.entries(advancedProperties)
+          .filter(([, v]) => typeof v['x-ui-order'] === 'number')
+          .sort((a, b) => (a[1]['x-ui-order'] as number) - (b[1]['x-ui-order'] as number));
+        const advWithoutOrder = Object.entries(advancedProperties)
+          .filter(([, v]) => typeof v['x-ui-order'] !== 'number');
+        const sortedAdvancedProperties = Object.fromEntries([...advWithOrder, ...advWithoutOrder]);
+
+        finalProperties['showAdvancedSettings'] = {
+          title: 'Show Advanced Settings',
+          type: 'boolean',
+          default: false,
+        };
+        generatedDependencies['showAdvancedSettings'] = {
+          if: {
+            properties: {
+              showAdvancedSettings: { const: true },
+            },
+          },
+          then: {
+            properties: sortedAdvancedProperties,
+          },
+        };
+      }
+
+      return { properties: finalProperties, dependencies: generatedDependencies };
     };
 
-    const rawSpec = version.schema?.openAPIV3Schema?.properties?.spec
+    const { properties: rawSpec, dependencies: specDependencies } = version.schema?.openAPIV3Schema?.properties?.spec
       ? processProperties(version.schema.openAPIV3Schema.properties.spec.properties)
-      : {};
+      : { properties: {}, dependencies: {} };
 
     // Sort spec fields by x-ui-order annotation when present.
     // Fields with x-ui-order are placed first (ascending), fields without it
@@ -839,6 +917,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     const additionalParameters = {
       title: 'Resource Spec',
       properties: processedSpec,
+      dependencies: specDependencies,
       type: 'object',
     };
     // Crossplane settings
@@ -1828,7 +1907,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
 
       for (const [key, value] of Object.entries(properties)) {
         const typedValue = value as Record<string, any>;
-        
+
         // Handle fields with x-kubernetes-preserve-unknown-fields: true
         if (typedValue['x-kubernetes-preserve-unknown-fields'] === true && !typedValue.type) {
           const { required: _, ...restValue } = typedValue;

--- a/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-hidden-advanced.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-hidden-advanced.md
@@ -1,0 +1,252 @@
+# XRD Form Visibility with `x-ui-hidden` and `x-ui-advanced`
+
+The `kubernetes-ingestor` plugin supports two vendor-extension annotations on XRD
+`openAPIV3Schema` properties to control how fields appear in the generated Backstage
+scaffolder template form.
+
+Both extensions apply to **XRD only** (`XRDTemplateEntityProvider`).
+
+---
+
+## `x-ui-hidden`
+
+```yaml
+# inside openAPIV3Schema.properties.spec.properties
+internalRef:
+  type: string
+  x-ui-hidden: true
+```
+
+When `x-ui-hidden: true` is set on a property, the field is **completely excluded** from the
+generated JSON Schema that drives the scaffolder form. RJSF never sees it — the field is not
+rendered, not validated, and not included in `formData`.
+
+### When to use it
+
+- **Fields in migration** — the XRD schema still contains the field (needed by Crossplane
+  compositions or for backward compatibility), but you want to stop exposing it to users while
+  the migration is in progress. The field remains valid in the XRD, so Crossplane can still
+  read and patch it; it simply does not appear in the Backstage form.
+- **Internal / system-managed values** — fields set programmatically by a mutating webhook,
+  composition patch, or environment controller that should never be provided by the user.
+- **Noisy defaults** — fields whose value is always fixed and clutters the form.
+
+### Scope
+
+The annotation applies to:
+
+- Top-level `spec` properties
+- Nested object properties (recursive — any depth)
+
+### Example
+
+```yaml
+---
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: myapps.infra.example.com
+spec:
+  group: infra.example.com
+  scope: Cluster
+  names:
+    kind: MyApp
+    plural: myapps
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+
+                # Regular field — shown in the form
+                replicas:
+                  type: integer
+                  default: 1
+                  description: Number of replicas.
+
+                # Field being migrated away from user input.
+                # Crossplane compositions still read it, but users should not set it.
+                legacyNetworkMode:
+                  type: string
+                  x-ui-hidden: true
+                  description: >
+                    Deprecated internal network selector. Managed by the composition.
+
+                # Nested hidden field
+                config:
+                  type: object
+                  properties:
+                    publicEndpoint:
+                      type: string
+                      description: Public-facing endpoint URL.
+                    internalToken:
+                      type: string
+                      x-ui-hidden: true
+                      description: Injected by the mutating webhook — do not set manually.
+```
+
+In the example above the Backstage form renders `replicas` and `config.publicEndpoint` but
+omits `legacyNetworkMode` and `config.internalToken` entirely.
+
+---
+
+## `x-ui-advanced`
+
+```yaml
+debugMode:
+  type: boolean
+  default: false
+  x-ui-advanced: true
+
+timeout:
+  type: string
+  default: 30s
+  x-ui-advanced: true
+```
+
+Fields marked with `x-ui-advanced: true` are moved out of the main `properties` section into
+a conditional [JSON Schema `if/then` dependency](https://json-schema.org/understanding-json-schema/reference/conditionals.html).
+The plugin automatically injects a `showAdvancedSettings` boolean toggle:
+
+```json
+{
+  "properties": {
+    "showAdvancedSettings": {
+      "title": "Show Advanced Settings",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "dependencies": {
+    "showAdvancedSettings": {
+      "if": { "properties": { "showAdvancedSettings": { "const": true } } },
+      "then": {
+        "properties": {
+          "debugMode": { "type": "boolean" },
+          "timeout":   { "type": "string", "ui:placeholder": "30s" }
+        }
+      }
+    }
+  }
+}
+```
+
+Advanced fields are invisible by default and only revealed once the user enables the toggle.
+
+### Default handling for advanced fields
+
+RJSF auto-populates `formData` with every field that has a `default`, even for fields the user
+never touched. For advanced fields this would cause their defaults to appear in every generated
+manifest. To prevent silent manifest pollution the plugin applies the following rules when
+moving a field to the advanced section:
+
+| Field type | Behaviour |
+|---|---|
+| Non-boolean with `default` | `default` removed; value moved to `ui:placeholder` (hint text only) |
+| Boolean with `default` | `default` removed (booleans cannot use `ui:placeholder`) |
+| No `default` | No change |
+
+The `x-ui-advanced` marker is stripped from the field definition before it is placed in the
+dependency, so it does not appear in generated YAML.
+
+### Example
+
+```yaml
+---
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: myapps.infra.example.com
+spec:
+  group: infra.example.com
+  scope: Cluster
+  names:
+    kind: MyApp
+    plural: myapps
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+
+                # Always-visible fields
+                replicas:
+                  type: integer
+                  default: 1
+
+                size:
+                  type: string
+                  enum: [small, medium, large]
+
+                # Advanced fields — hidden behind the toggle
+                debugMode:
+                  type: boolean
+                  default: false
+                  x-ui-advanced: true
+                  description: Enable verbose logging (advanced).
+
+                timeout:
+                  type: string
+                  default: 30s
+                  x-ui-advanced: true
+                  description: Request timeout override (advanced).
+
+                networking:
+                  type: object
+                  properties:
+                    mode:
+                      type: string
+                      default: overlay
+                    mtu:
+                      type: integer
+                      default: 1500
+                      x-ui-advanced: true  # only mtu is advanced within the object
+```
+
+---
+
+## Combining `x-ui-hidden` and `x-ui-advanced`
+
+Both extensions can be used together in the same XRD:
+
+```yaml
+spec:
+  properties:
+
+    region:
+      type: string          # regular visible field
+
+    internalRef:
+      type: string
+      x-ui-hidden: true      # never shown in the form
+
+    tuning:
+      type: string
+      default: "auto"
+      x-ui-advanced: true    # shown only when "Show Advanced Settings" is toggled
+```
+
+---
+
+## Notes
+
+- Both annotations are vendor extensions and are **not** part of Kubernetes CRD validation.
+  They are processed at template-generation time by this plugin and have no effect on the
+  Crossplane runtime. They apply only to **XRD** (`XRDTemplateEntityProvider`).
+- `x-ui-hidden` and `x-ui-advanced` are mutually exclusive on the same field: a field with
+  `x-ui-hidden: true` is dropped before the advanced-grouping step, so combining both on one
+  field is redundant (the field will simply be hidden).
+- For details on controlling field order see
+  [XRD Field Ordering (`x-ui-order`)](./xrd-ui-order.md).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
               - Install: plugins/kubernetes-ingestor/backend/install.md
               - Configure: plugins/kubernetes-ingestor/backend/configure.md
               - XRD Field Ordering (x-ui-order): plugins/kubernetes-ingestor/backend/xrd-ui-order.md
+              - XRD Form Visibility (x-ui-hidden, x-ui-advanced): plugins/kubernetes-ingestor/backend/xrd-ui-hidden-advanced.md
       - Crossplane:
           - Overview: plugins/crossplane/overview.md
           - Backend:


### PR DESCRIPTION
Add x-ui-hidden and x-ui-advanced support for XRD scaffolder templates

What
The kubernetes-ingestor plugin now supports two new vendor extensions on XRD spec properties that control field visibility in generated Backstage scaffolder templates.

Behaviour
x-ui-hidden: true Fields marked with this annotation are completely excluded from the generated template form. Useful for internal/operator-managed fields that should not be exposed to end users.

x-ui-advanced: true Fields marked with this annotation are grouped under a collapsible "Show Advanced Settings" toggle (RJSF conditional dependency). Default values are stripped and replaced with ui:placeholder to prevent them from being silently injected into every generated manifest when the user never touches those fields.

Changes
EntityProvider.ts — processProperties now filters x-ui-hidden fields and moves x-ui-advanced fields into a conditional dependency block with defaults removed
EntityProvider.test.ts — new test suite covering hidden/advanced field scenarios
site/docs/…/xrd-ui-hidden-advanced.md — documentation with examples and rules summary
site/mkdocs.yml — added navigation entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI annotations: fields marked hidden are excluded from generated spec and form data; fields marked advanced are relocated under a conditional "Advanced settings" toggle (added only when needed), ordered numerically, applied recursively, and have defaults adjusted (non-boolean → placeholder, boolean defaults removed).

* **Documentation**
  * Added backend docs with examples and processing notes for the annotations.

* **Tests**
  * Expanded unit tests for hidden/advanced behavior, ordering, defaults, nested properties, and conditional grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->