### PR TITLE
make x-ui-order reflect generated XR field order

### DIFF
--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3275,7 +3275,7 @@ describe('XRDTemplateEntityProvider', () => {
       const params = (provider as any).extractParameters(
         makeVersion({
           affinity:  { type: 'string', 'x-ui-advanced': true, 'x-ui-order': 7, default: 'None' },
-          statefull: { type: 'boolean', 'x-ui-advanced': true, 'x-ui-order': 1, default: false },
+          stateful: { type: 'boolean', 'x-ui-advanced': true, 'x-ui-order': 1, default: false },
         }),
         ['test-cluster'],
         makeXrd(),
@@ -3283,8 +3283,8 @@ describe('XRDTemplateEntityProvider', () => {
       const specGroup = params.find((p: any) => p.title === 'Resource Spec');
       const dep = specGroup.dependencies?.showAdvancedSettings;
       const keys = Object.keys(dep.then.properties);
-      // statefull (x-ui-order: 1) must appear before affinity (x-ui-order: 7)
-      expect(keys.indexOf('statefull')).toBeLessThan(keys.indexOf('affinity'));
+      // stateful (x-ui-order: 1) must appear before affinity (x-ui-order: 7)
+      expect(keys.indexOf('stateful')).toBeLessThan(keys.indexOf('affinity'));
     });
 
     it('propagates nested object advanced fields into sub-dependencies', () => {
@@ -3556,6 +3556,105 @@ describe('XRDTemplateEntityProvider', () => {
       expect(apis[0].metadata.annotations['backstage.io/source-location']).toBe('url:https://github.com/org/repo');
       expect(apis[0].metadata.annotations['custom.io/team']).toBe('platform');
       expect(apis[0].metadata.annotations['backstage.io/managed-by-location']).toBe('cluster origin: test-cluster');
+    });
+  });
+
+  // ── extractSteps – showAdvancedSettings exclusion & specFieldOrder ────────────
+
+  describe('extractSteps – showAdvancedSettings and specFieldOrder', () => {
+    const makeStepsProvider = () =>
+      new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        mockConfig,
+        mockResourceFetcher as any,
+      );
+
+    const makeXrdForSteps = () => ({
+      metadata: { name: 'myresources.example.com' },
+      spec: {
+        scope: 'Cluster',
+        names: { kind: 'MyResource', plural: 'myresources' },
+        group: 'example.com',
+      },
+    });
+
+    const makeVersionWithOrder = (specProps: Record<string, any>) => ({
+      name: 'v1alpha1',
+      schema: {
+        openAPIV3Schema: {
+          type: 'object',
+          properties: {
+            spec: { type: 'object', properties: specProps },
+          },
+        },
+      },
+    });
+
+    const getGenerateStep = (steps: any[]) => steps.find((s: any) => s.id === 'generateManifest');
+
+    it('includes showAdvancedSettings in excludeParams in generated steps', () => {
+      const provider = makeStepsProvider();
+      const version = makeVersionWithOrder({
+        dc: { type: 'string', 'x-ui-order': 1 },
+        affinity: { type: 'string', 'x-ui-advanced': true, 'x-ui-order': 7 },
+      });
+
+      const steps: any[] = (provider as any).extractSteps(version, makeXrdForSteps());
+      const step = getGenerateStep(steps);
+      expect(step).toBeDefined();
+      expect(step.input.excludeParams).toContain('showAdvancedSettings');
+    });
+
+    it('generates specFieldOrder sorted by x-ui-order', () => {
+      const provider = makeStepsProvider();
+      const version = makeVersionWithOrder({
+        gamma: { type: 'string', 'x-ui-order': 3 },
+        alpha: { type: 'string', 'x-ui-order': 1 },
+        beta:  { type: 'string', 'x-ui-order': 2 },
+      });
+
+      const steps: any[] = (provider as any).extractSteps(version, makeXrdForSteps());
+      const step = getGenerateStep(steps);
+      expect(step.input.specFieldOrder).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('includes x-ui-advanced fields in specFieldOrder based on x-ui-order', () => {
+      const provider = makeStepsProvider();
+      const version = makeVersionWithOrder({
+        cluster:   { type: 'string', 'x-ui-order': 2 },
+        dc:        { type: 'string', 'x-ui-order': 1 },
+        stateful: { type: 'boolean', 'x-ui-advanced': true, 'x-ui-order': 1 },
+        affinity:  { type: 'string',  'x-ui-advanced': true, 'x-ui-order': 7 },
+      });
+
+      const steps: any[] = (provider as any).extractSteps(version, makeXrdForSteps());
+      const order: string[] = getGenerateStep(steps).input.specFieldOrder;
+      expect(order.indexOf('dc')).toBeLessThan(order.indexOf('cluster'));
+      expect(order.indexOf('stateful')).toBeLessThan(order.indexOf('cluster'));
+      expect(order.indexOf('stateful')).toBeLessThan(order.indexOf('affinity'));
+    });
+
+    it('does not include x-ui-hidden fields in specFieldOrder', () => {
+      const provider = makeStepsProvider();
+      const version = makeVersionWithOrder({
+        visible: { type: 'string', 'x-ui-order': 1 },
+        hidden:  { type: 'string', 'x-ui-hidden': true, 'x-ui-order': 0 },
+      });
+
+      const steps: any[] = (provider as any).extractSteps(version, makeXrdForSteps());
+      const order: string[] = getGenerateStep(steps).input.specFieldOrder;
+      expect(order).toContain('visible');
+      expect(order).not.toContain('hidden');
+    });
+
+    it('omits specFieldOrder when no spec properties exist', () => {
+      const provider = makeStepsProvider();
+      const version = { name: 'v1alpha1', schema: { openAPIV3Schema: { type: 'object', properties: {} } } };
+
+      const steps: any[] = (provider as any).extractSteps(version, makeXrdForSteps());
+      const step = getGenerateStep(steps);
+      expect(step.input.specFieldOrder).toBeUndefined();
     });
   });
 });

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -1399,6 +1399,25 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     const isCluster = scope === 'Cluster';
     const isNamespaced = scope === 'Namespaced';
     // --- END VERSION/SCOPE LOGIC REFACTOR ---
+
+    // Compute specFieldOrder from x-ui-order annotations in the XRD spec properties.
+    // All visible fields (regular and x-ui-advanced) are sorted together by x-ui-order,
+    // matching the logical ordering intent in the XRD schema.
+    const rawSpecProps: Record<string, any> = version.schema?.openAPIV3Schema?.properties?.spec?.properties || {};
+    const visibleSpecFields = Object.entries(rawSpecProps).filter(([, v]) => (v as any)['x-ui-hidden'] !== true);
+    const specFieldsWithOrder = visibleSpecFields
+      .filter(([, v]) => typeof (v as any)['x-ui-order'] === 'number')
+      .sort((a, b) => (a[1] as any)['x-ui-order'] - (b[1] as any)['x-ui-order'])
+      .map(([k]) => k);
+    const specFieldsWithoutOrder = visibleSpecFields
+      .filter(([, v]) => typeof (v as any)['x-ui-order'] !== 'number')
+      .map(([k]) => k)
+      .sort();
+    const specFieldOrder = [...specFieldsWithOrder, ...specFieldsWithoutOrder];
+    const specFieldOrderYaml = specFieldOrder.length > 0
+      ? '    specFieldOrder: [' + specFieldOrder.map(f => `'${f}'`).join(', ') + ']\n'
+      : '';
+
     let baseStepsYaml = '';
     // Compose the YAML as a string, not a template literal with JS expressions inside
     if (isV2 && (isCluster || isNamespaced) && !isLegacyCluster) {
@@ -1412,11 +1431,12 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         '    nameParam: xrName\n' +
         (isNamespaced ? '    namespaceParam: xrNamespace\n' : '    namespaceParam: ""\n') +
         '    ownerParam: owner\n' +
-        '    excludeParams: [\'crossplane.compositionSelectionStrategy\',\'owner\',\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\',\'targetBranch\',\'repoUrl\',\'clusters\',\'xrName\'' + (isNamespaced ? ', \'xrNamespace\'' : '') + ']\n' +
+        '    excludeParams: [\'crossplane.compositionSelectionStrategy\',\'owner\',\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\',\'targetBranch\',\'repoUrl\',\'clusters\',\'xrName\',\'showAdvancedSettings\'' + (isNamespaced ? ', \'xrNamespace\'' : '') + ']\n' +
         '    apiVersion: {API_VERSION}\n' +
         '    kind: {KIND}\n' +
         '    clusters: ${{ parameters.clusters if parameters.manifestLayout === \'cluster-scoped\' and parameters.pushToGit else [\'temp\'] }}\n' +
-        '    removeEmptyParams: true\n';
+        '    removeEmptyParams: true\n' +
+        specFieldOrderYaml;
     } else {
       // v1 or v2 LegacyCluster: keep current logic
       baseStepsYaml =
@@ -1428,11 +1448,12 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         '    nameParam: xrName\n' +
         '    namespaceParam: xrNamespace\n' +
         '    ownerParam: owner\n' +
-        '    excludeParams: [\'owner\', \'compositionSelectionStrategy\',\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\', \'targetBranch\', \'repoUrl\', \'clusters\', \'xrName\', \'xrNamespace\']\n' +
+        '    excludeParams: [\'owner\', \'compositionSelectionStrategy\',\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\', \'targetBranch\', \'repoUrl\', \'clusters\', \'xrName\', \'xrNamespace\', \'showAdvancedSettings\']\n' +
         '    apiVersion: {API_VERSION}\n' +
         '    kind: {KIND}\n' +
         '    clusters: ${{ parameters.clusters if parameters.manifestLayout === \'cluster-scoped\' and parameters.pushToGit else [\'temp\'] }}\n' +
-        '    removeEmptyParams: true\n'
+        '    removeEmptyParams: true\n' +
+        specFieldOrderYaml
     }
     const publishPhaseTarget = this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.target')?.toLowerCase();
     let action = '';

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
@@ -1,6 +1,7 @@
 import { createCrossplaneClaimAction } from './claim-templating';
 import { ConfigReader } from '@backstage/config';
 import fs from 'fs-extra';
+import yaml from 'js-yaml';
 
 jest.mock('fs-extra');
 
@@ -379,6 +380,90 @@ describe('createCrossplaneClaimAction', () => {
       await action.handler!(ctx as any);
 
       expect(fs.outputFileSync).toHaveBeenCalled();
+    });
+
+    it('should always exclude showAdvancedSettings from the manifest spec', async () => {
+      const action = createCrossplaneClaimAction({ config: mockConfig });
+      const ctx = createMockContext({
+        parameters: {
+          xrName: 'test-claim',
+          xrNamespace: 'test-ns',
+          showAdvancedSettings: true,
+          someParam: 'value',
+        },
+        nameParam: 'xrName',
+        namespaceParam: 'xrNamespace',
+        excludeParams: ['xrName', 'xrNamespace'],
+        apiVersion: 'test.io/v1',
+        kind: 'TestClaim',
+        clusters: ['cluster-1'],
+        removeEmptyParams: false,
+        ownerParam: 'owner',
+      });
+
+      await action.handler!(ctx as any);
+
+      const writtenContent: string = (fs.outputFileSync as jest.Mock).mock.calls[0][1];
+      const manifest = yaml.load(writtenContent) as any;
+      expect(manifest.spec).not.toHaveProperty('showAdvancedSettings');
+      expect(manifest.spec).toHaveProperty('someParam', 'value');
+    });
+
+    it('should order spec fields according to specFieldOrder', async () => {
+      const action = createCrossplaneClaimAction({ config: mockConfig });
+      const ctx = createMockContext({
+        parameters: {
+          xrName: 'test-claim',
+          xrNamespace: 'test-ns',
+          gamma: 'g',
+          alpha: 'a',
+          beta: 'b',
+        },
+        nameParam: 'xrName',
+        namespaceParam: 'xrNamespace',
+        excludeParams: ['xrName', 'xrNamespace'],
+        apiVersion: 'test.io/v1',
+        kind: 'TestClaim',
+        clusters: ['cluster-1'],
+        removeEmptyParams: false,
+        ownerParam: 'owner',
+        specFieldOrder: ['alpha', 'beta', 'gamma'],
+      });
+
+      await action.handler!(ctx as any);
+
+      const writtenContent: string = (fs.outputFileSync as jest.Mock).mock.calls[0][1];
+      const manifest = yaml.load(writtenContent) as any;
+      const specKeys = Object.keys(manifest.spec);
+      expect(specKeys).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('should place fields not in specFieldOrder after ordered fields', async () => {
+      const action = createCrossplaneClaimAction({ config: mockConfig });
+      const ctx = createMockContext({
+        parameters: {
+          xrName: 'test-claim',
+          xrNamespace: 'test-ns',
+          extra: 'e',
+          first: 'f',
+        },
+        nameParam: 'xrName',
+        namespaceParam: 'xrNamespace',
+        excludeParams: ['xrName', 'xrNamespace'],
+        apiVersion: 'test.io/v1',
+        kind: 'TestClaim',
+        clusters: ['cluster-1'],
+        removeEmptyParams: false,
+        ownerParam: 'owner',
+        specFieldOrder: ['first'],
+      });
+
+      await action.handler!(ctx as any);
+
+      const writtenContent: string = (fs.outputFileSync as jest.Mock).mock.calls[0][1];
+      const manifest = yaml.load(writtenContent) as any;
+      const specKeys = Object.keys(manifest.spec);
+      expect(specKeys).toEqual(['first', 'extra']);
     });
   });
 });

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
@@ -42,12 +42,13 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
         parameters: z => z.record(z.any()).describe('Pass through of input parameters'),
         nameParam: z => z.string().describe('Template parameter to map to the name of the claim').default('xrName'),
         namespaceParam: z => z.string().describe('Template parameter to map to the namespace of the claim').default('xrNamespace'),
-        excludeParams: z => z.array(z.string()).describe('Template parameters to exclude from the claim').default(['xrName', 'xrNamespace', 'clusters', 'targetBranch', 'repoUrl', '_editData']),
+        excludeParams: z => z.array(z.string()).describe('Template parameters to exclude from the claim').default(['xrName', 'xrNamespace', 'clusters', 'targetBranch', 'repoUrl', '_editData', 'showAdvancedSettings']),
         apiVersion: z => z.string().describe('API Version of the claim'),
         kind: z => z.string().describe('Kind of the claim'),
         clusters: z => z.array(z.string()).min(1).describe('The target clusters to apply the resource to'),
         removeEmptyParams: z => z.boolean().describe('If set to false, empty parameters will be rendered in the manifest. by default they are removed').default(true),
         ownerParam: z => z.string().describe('Template parameter to map to the owner of the claim'),
+        specFieldOrder: z => z.array(z.string()).describe('Ordered list of spec field names (derived from x-ui-order) to control key order in the generated manifest').optional(),
       },
       output: {
         manifest: z => z.string().describe('The templated Kubernetes resource manifest'),
@@ -67,7 +68,7 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
         throw new Error(`myParameter cannot be 'foo'`);
       }
 
-      // Remove excluded parameters
+      // Remove excluded parameters (always exclude showAdvancedSettings regardless of excludeParams list)
       const filteredParameters = { ...input.parameters };
       // Helper to delete nested keys using dot notation
       function deleteNested(obj: any, path: string) {
@@ -79,9 +80,24 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
         }
         delete current[parts[parts.length - 1]];
       }
-      input.excludeParams.forEach((param: string) => {
-        deleteNested(filteredParameters, param);
+      function removeNestedKey(obj: any, keyName: string) {
+        if (Array.isArray(obj)) {
+          obj.forEach(item => removeNestedKey(item, keyName));
+          return;
+        }
+        if (!obj || typeof obj !== 'object') {
+          return;
+        }
+        delete obj[keyName];
+        Object.values(obj).forEach(value => removeNestedKey(value, keyName));
+      }
+      const excludeSet = new Set([...input.excludeParams, 'showAdvancedSettings']);
+      excludeSet.forEach((param: string) => {
+        if (param !== 'showAdvancedSettings') {
+          deleteNested(filteredParameters, param);
+        }
       });
+      removeNestedKey(filteredParameters, 'showAdvancedSettings');
 
       // Remove empty parameters if removeEmptyParams is true
       if (input.removeEmptyParams) {
@@ -150,6 +166,23 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
           sourceFileUrl = generateSourceFileUrl(sourceInfo.gitRepo, sourceInfo.gitBranch, filePath, scmType);
         }
 
+        // Reorder spec fields according to specFieldOrder (derived from x-ui-order in XRD)
+        let specObj: Record<string, any> = filteredParameters;
+        if (input.specFieldOrder && input.specFieldOrder.length > 0) {
+          const ordered: Record<string, any> = {};
+          for (const key of input.specFieldOrder) {
+            if (key in filteredParameters) {
+              ordered[key] = filteredParameters[key];
+            }
+          }
+          for (const key of Object.keys(filteredParameters)) {
+            if (!(key in ordered)) {
+              ordered[key] = filteredParameters[key];
+            }
+          }
+          specObj = ordered;
+        }
+
         // Create the manifest with the correct annotation for this cluster
         const manifest = {
           apiVersion: input.apiVersion,
@@ -165,7 +198,7 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
             name: (input.parameters as any)[input.nameParam],
             ...((input.parameters as any)[input.namespaceParam] && (input.parameters as any)[input.namespaceParam] !== '' ? { namespace: (input.parameters as any)[input.namespaceParam] } : {}),
           },
-          spec: filteredParameters,
+          spec: specObj,
         };
 
         manifestYaml = yaml.dump(manifest, {

--- a/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-order.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-order.md
@@ -227,6 +227,20 @@ order instead of the schema-declaration order.
 
 ---
 
+## What affects XR file generation
+
+For `x-ui-*` annotations, the generated XR manifest file is affected by these rules:
+
+| Factor | Effect on generated XR file |
+|---|---|
+| `x-ui-order` on `spec` fields | Defines `specFieldOrder`, which controls key order in `spec` inside the generated YAML |
+| Missing `x-ui-order` | Such fields are appended after ordered ones (alphabetically) |
+| `x-ui-hidden: true` | Field is hidden from UI/form ordering (`specFieldOrder`), but it is not auto-removed from generated `spec` unless explicitly excluded via `excludeParams` |
+| `x-ui-advanced: true` | Field is grouped behind `showAdvancedSettings` in UI, but still participates in `x-ui-order` when enabled |
+| `x-ui-advanced` UI toggle field (`showAdvancedSettings`) | Is UI-only and never written to XR `spec` |
+
+---
+
 ## Notes
 
 - `x-ui-order` must be a **number** (integer or float). String values are ignored.


### PR DESCRIPTION
## Summary
- Added support to propagate `specFieldOrder` from XRD (`x-ui-order`) into `terasky:claim-template` so generated XR `spec` keys follow schema order, not alphabetical order.
- Ensured `showAdvancedSettings` is always treated as UI-only and never written to XR manifests.
- Updated docs (`xrd-ui-order.md`) to clarify how `x-ui-*` annotations affect generated XR files.

## Why
Generated XR files in PRs were not matching the intended order from XRD schema (`x-ui-order`), and UI toggle fields could leak into manifest spec.

## Changes
- `plugins/kubernetes-ingestor/src/providers/EntityProvider.ts`
  - Compute and pass `specFieldOrder` to claim-template step.
  - Include `showAdvancedSettings` in excluded params for generated steps.
- `plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts`
  - Accept optional `specFieldOrder`.
  - Reorder `spec` keys before YAML generation.
  - Always exclude `showAdvancedSettings` from output spec.
- Tests updated:
  - `EntityProvider.test.ts`
  - `claim-templating.test.ts`
- Docs updated:
  - `site/docs/plugins/kubernetes-ingestor/backend/xrd-ui-order.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic spec key ordering in generated manifests driven by x-ui-order; fields without x-ui-order are appended alphabetically.
  * showAdvancedSettings is always excluded from generated specs.
  * Optional input to supply a specFieldOrder to enforce manifest key ordering.

* **Bug Fixes**
  * x-ui-advanced fields now follow x-ui-order rules instead of being forced to the end.

* **Documentation**
  * Added guidance on how x-ui-* annotations affect generated XR YAML and forms.

* **Tests**
  * Added tests validating exclusion of showAdvancedSettings and deterministic spec ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeraSky-OSS/backstage-plugins/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->