### PR TITLE
New "none" systemModel when no default system is wanted

### DIFF
--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -138,7 +138,10 @@ export interface Config {
       titleModel?: string;
       /**
        * Model for determining system assignments
-       * Options: namespace, cluster, cluster-namespace
+       * Options: namespace, cluster, cluster-namespace, default, none
+       * Use "none" to only assign a system when the component explicitly
+       * provides one via the `<prefix>/system` annotation. In that case no
+       * System entity is auto-created.
        * @default namespace
        * @visibility frontend
        */

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -1528,6 +1528,197 @@ describe('KubernetesEntityProvider', () => {
       });
     });
 
+    describe('Given systemModel "none"', () => {
+      const mockResource = (annotations: any = {}) => ({
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: { name: 'test-deployment', namespace: 'team-platform', annotations },
+        spec: {},
+        clusterName: 'test-cluster',
+      });
+
+      it('When no system annotation, Then no system is assigned and no System entity is created', async () => {
+        const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+        const entities = await (provider as any).translateKubernetesObjectsToEntities(mockResource());
+
+        expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+        const component = entities.find((e: any) => e.kind === 'Component');
+        expect(component.spec.system).toBeUndefined();
+      });
+
+      it('When system annotation is set, Then it is assigned but no System entity is created', async () => {
+        const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+        const entities = await (provider as any).translateKubernetesObjectsToEntities(
+          mockResource({ 'terasky.backstage.io/system': 'my-system' }),
+        );
+
+        expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+        const component = entities.find((e: any) => e.kind === 'Component');
+        expect(component.spec.system).toBe('my-system');
+      });
+
+      describe('Crossplane claims', () => {
+        const createMockClaim = (annotations: any = {}) => ({
+          apiVersion: 'database.example.com/v1alpha1',
+          kind: 'PostgreSQLInstance',
+          metadata: { name: 'my-db', namespace: 'test-namespace', annotations },
+          spec: {
+            resourceRef: {
+              apiVersion: 'database.example.com/v1alpha1',
+              kind: 'XPostgreSQLInstance',
+              name: 'my-db-abc123',
+            },
+          },
+          clusterName: 'test-cluster',
+        });
+
+        const crdMapping = {
+          'database.example.com|PostgreSQLInstance': 'postgresqlinstances',
+          'database.example.com|XPostgreSQLInstance': 'xpostgresqlinstances',
+        };
+
+        it('When no system annotation, Then spec.system is undefined and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+          const entities = await (provider as any).translateCrossplaneClaimToEntity(
+            createMockClaim(),
+            'test-cluster',
+            crdMapping,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBeUndefined();
+        });
+
+        it('When system annotation is set, Then it is assigned and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+          const entities = await (provider as any).translateCrossplaneClaimToEntity(
+            createMockClaim({ 'terasky.backstage.io/system': 'my-system' }),
+            'test-cluster',
+            crdMapping,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBe('my-system');
+        });
+      });
+
+      describe('Crossplane composites (XRs)', () => {
+        const createMockXR = (annotations: any = {}) => ({
+          apiVersion: 'database.example.com/v1alpha1',
+          kind: 'XPostgreSQLInstance',
+          metadata: { name: 'my-db-abc123', namespace: 'test-namespace', annotations },
+          spec: { crossplane: { compositionRef: { name: 'my-composition' } } },
+          clusterName: 'test-cluster',
+        });
+
+        const compositeKindLookup = {
+          'XPostgreSQLInstance|database.example.com|v1alpha1': {
+            scope: 'Namespaced',
+            spec: { names: { plural: 'xpostgresqlinstances' } },
+          },
+        };
+
+        it('When no system annotation, Then spec.system is undefined and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+          const entities = await (provider as any).translateCrossplaneCompositeToEntity(
+            createMockXR(),
+            'test-cluster',
+            compositeKindLookup,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBeUndefined();
+        });
+
+        it('When system annotation is set, Then it is assigned and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' } });
+
+          const entities = await (provider as any).translateCrossplaneCompositeToEntity(
+            createMockXR({ 'terasky.backstage.io/system': 'my-system' }),
+            'test-cluster',
+            compositeKindLookup,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBe('my-system');
+        });
+      });
+
+      describe('KRO instances', () => {
+        const createMockKROInstance = (annotations: any = {}) => ({
+          apiVersion: 'kro.example.com/v1alpha1',
+          kind: 'ApplicationInstance',
+          metadata: {
+            name: 'my-app',
+            namespace: 'test-namespace',
+            annotations,
+            labels: { 'kro.run/resource-graph-definition-id': 'app-instance-rgd' },
+          },
+          spec: {},
+          clusterName: 'test-cluster',
+        });
+
+        const kroRgdLookup = {
+          'ApplicationInstance|kro.example.com|v1alpha1': {
+            rgd: {
+              metadata: { name: 'applicationinstances' },
+              spec: {
+                schema: {
+                  kind: 'ApplicationInstance',
+                  plural: 'applicationinstances',
+                  group: 'kro.example.com',
+                  version: 'v1alpha1',
+                },
+                resources: [],
+              },
+            },
+            spec: {
+              names: { kind: 'ApplicationInstance', plural: 'applicationinstances' },
+              group: 'kro.example.com',
+              version: 'v1alpha1',
+            },
+          },
+        };
+
+        it('When no system annotation, Then spec.system is undefined and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' }, kro: { enabled: true } });
+
+          const entities = await (provider as any).translateKROInstanceToEntity(
+            createMockKROInstance(),
+            'test-cluster',
+            kroRgdLookup,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBeUndefined();
+        });
+
+        it('When system annotation is set, Then it is assigned and no System entity is created', async () => {
+          const provider = createProviderWithConfig({ mappings: { systemModel: 'none' }, kro: { enabled: true } });
+
+          const entities = await (provider as any).translateKROInstanceToEntity(
+            createMockKROInstance({ 'terasky.backstage.io/system': 'my-system' }),
+            'test-cluster',
+            kroRgdLookup,
+          );
+
+          expect(entities.find((e: any) => e.kind === 'System')).toBeUndefined();
+          const component = entities.find((e: any) => e.kind === 'Component');
+          expect(component.spec.system).toBe('my-system');
+        });
+      });
+    });
+
     describe('Given namespace annotations cache', () => {
       const createMockWorkload = (annotations: any = {}, namespace: string = 'test-namespace', name: string = 'test-deployment') => ({
         apiVersion: 'apps/v1',

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -2910,6 +2910,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       } else {
         systemNameValue = `${normalizedClusterName}`;
       }
+    } else if (systemNameModel === 'none') {
+      systemNameValue = '';
     } else {
       systemNameValue = 'default';
     }
@@ -2998,7 +3000,9 @@ export class KubernetesEntityProvider implements EntityProvider {
       this.getDefaultOwner(),
     );
 
-    const systemEntity: Entity = {
+    // With systemModel "none" we never auto-create a System entity; the
+    // component is only linked to an explicitly provided system, if any.
+    const systemEntity: Entity | undefined = systemNameModel === 'none' ? undefined : {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'System',
       metadata: {
@@ -3032,7 +3036,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       systemReferencesNamespaceValue,
       this.getDefaultOwner(),
     );
-    const componentSystem = annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`;
+    const componentSystem = annotations[`${prefix}/system`]
+      || (systemNameModel === 'none' ? undefined : `${systemReferencesNamespaceValue}/${systemNameValue}`);
 
     // Try to fetch API definition from annotations
     let apiEntity: Entity | undefined;
@@ -3099,7 +3104,7 @@ export class KubernetesEntityProvider implements EntityProvider {
         type: annotations[`${prefix}/component-type`] || resource.workloadType || 'service',
         lifecycle: annotations[`${prefix}/lifecycle`] || 'production',
         owner: componentOwner,
-        system: annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`,
+        ...(componentSystem ? { system: componentSystem } : {}),
         dependsOn: splitAnnotationValues(annotations[`${prefix}/dependsOn`]),
         ...(entityKind === 'Component' ? {
           providesApis: providesApis,
@@ -3112,7 +3117,7 @@ export class KubernetesEntityProvider implements EntityProvider {
     };
 
     const entities: Entity[] = [];
-    if (this.validateEntityName(systemEntity)) {
+    if (systemEntity && this.validateEntityName(systemEntity)) {
       entities.push(systemEntity);
     }
     if (this.validateEntityName(componentEntity)) {
@@ -3198,6 +3203,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       } else {
         systemNameValue = `${normalizedClusterName}`;
       }
+    } else if (systemNameModel === 'none') {
+      systemNameValue = '';
     } else {
       systemNameValue = 'default';
     }
@@ -3246,7 +3253,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       systemReferencesNamespaceValue,
       this.getDefaultOwner(),
     );
-    const componentSystem = annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`;
+    const componentSystem = annotations[`${prefix}/system`]
+      || (systemNameModel === 'none' ? undefined : `${systemReferencesNamespaceValue}/${systemNameValue}`);
 
     // Try to fetch API definition from annotations
     let apiEntity: Entity | undefined;
@@ -3306,7 +3314,7 @@ export class KubernetesEntityProvider implements EntityProvider {
         type: annotations[`${prefix}/component-type`] || claim.workloadType || 'crossplane-claim',
         lifecycle: annotations[`${prefix}/lifecycle`] || 'production',
         owner: componentOwner,
-        system: annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`,
+        ...(componentSystem ? { system: componentSystem } : {}),
         dependsOn: splitAnnotationValues(annotations[`${prefix}/dependsOn`]),
         ...(entityKind === 'Component' ? {
           providesApis: providesApis,
@@ -3397,6 +3405,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       } else {
         systemNameValue = `${normalizedClusterName}`;
       }
+    } else if (systemNameModel === 'none') {
+      systemNameValue = '';
     } else {
       systemNameValue = 'default';
     }
@@ -3445,7 +3455,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       systemReferencesNamespaceValue,
       this.getDefaultOwner(),
     );
-    const componentSystem = annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`;
+    const componentSystem = annotations[`${prefix}/system`]
+      || (systemNameModel === 'none' ? undefined : `${systemReferencesNamespaceValue}/${systemNameValue}`);
 
     // Try to fetch API definition from annotations
     let apiEntity: Entity | undefined;
@@ -3504,7 +3515,7 @@ export class KubernetesEntityProvider implements EntityProvider {
         type: annotations[`${prefix}/component-type`] || instance.workloadType || 'kro-instance',
         lifecycle: annotations[`${prefix}/lifecycle`] || 'production',
         owner: componentOwner,
-        system: annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`,
+        ...(componentSystem ? { system: componentSystem } : {}),
         dependsOn: splitAnnotationValues(annotations[`${prefix}/dependsOn`]),
         ...(entityKind === 'Component' ? {
           providesApis: providesApis,
@@ -3596,6 +3607,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       } else {
         systemNameValue = `${normalizedClusterName}`;
       }
+    } else if (systemNameModel === 'none') {
+      systemNameValue = '';
     } else {
       systemNameValue = 'default';
     }
@@ -3644,7 +3657,8 @@ export class KubernetesEntityProvider implements EntityProvider {
       systemReferencesNamespaceValue,
       this.getDefaultOwner(),
     );
-    const componentSystem = annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`;
+    const componentSystem = annotations[`${prefix}/system`]
+      || (systemNameModel === 'none' ? undefined : `${systemReferencesNamespaceValue}/${systemNameValue}`);
 
     // Try to fetch API definition from annotations
     let apiEntity: Entity | undefined;
@@ -3701,7 +3715,7 @@ export class KubernetesEntityProvider implements EntityProvider {
         type: annotations[`${prefix}/component-type`] || xr.workloadType || 'crossplane-xr',
         lifecycle: annotations[`${prefix}/lifecycle`] || 'production',
         owner: componentOwner,
-        system: annotations[`${prefix}/system`] || `${systemReferencesNamespaceValue}/${systemNameValue}`,
+        ...(componentSystem ? { system: componentSystem } : {}),
         dependsOn: splitAnnotationValues(annotations[`${prefix}/dependsOn`]),
         ...(entityKind === 'Component' ? {
           providesApis: providesApis,
@@ -3912,7 +3926,7 @@ export class KubernetesEntityProvider implements EntityProvider {
     clusterName: string,
     definition: string,
     owner: string,
-    system: string,
+    system: string | undefined,
     useTextReference: boolean = false,
   ): Entity | undefined {
     try {
@@ -3942,7 +3956,7 @@ export class KubernetesEntityProvider implements EntityProvider {
           type: 'openapi',
           lifecycle: 'production',
           owner: owner,
-          system: system,
+          ...(system ? { system } : {}),
           definition: definitionValue,
         },
       };
@@ -3977,7 +3991,7 @@ export class KubernetesEntityProvider implements EntityProvider {
     clusterName: string,
     defaultNamespace: string,
     owner: string,
-    system: string,
+    system: string | undefined,
   ): Promise<{ entity: Entity; ref: string } | null> {
     try {
       const result = await this.apiDefinitionFetcher.fetchApiFromAnnotations(

--- a/site/docs/plugins/kubernetes-ingestor/backend/configure.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/configure.md
@@ -21,13 +21,13 @@ kubernetesIngestor:
   # namespaceModel: 'cluster' # cluster, namespace, default
   # nameModel: 'name-cluster' # name-cluster, name-namespace, name
   # titleModel: 'name' # name, name-cluster, name-namespace
-  # systemModel: 'cluster-namespace' # cluster, namespace, cluster-namespace, default
+  # systemModel: 'cluster-namespace' # cluster, namespace, cluster-namespace, default, none
   # referencesNamespaceModel: 'default' # default, same
   mappings:
     namespaceModel: 'cluster' # cluster, namespace, default
     nameModel: 'name-cluster' # name-cluster, name-namespace, name-kind, name, uid
     titleModel: 'name' # name, name-cluster, name-namespace
-    systemModel: 'namespace' # cluster, namespace, cluster-namespace, default
+    systemModel: 'namespace' # cluster, namespace, cluster-namespace, default, none
     referencesNamespaceModel: 'default' # default, same
   # Default owner for ingested entities when no owner annotation is set
   defaultOwner: 'kubernetes-auto-ingested'
@@ -838,6 +838,7 @@ Defines system mapping:
 - `namespace`: Use namespace name  
 - `cluster-namespace`: Combine both  
 - `default`: Use default system  
+- `none`: Do not assign a system unless the resource explicitly provides one via the `terasky.backstage.io/system` annotation. When a resource does not set that annotation, it is ingested without a `spec.system` and no `System` entity is auto-created for it.  
 
 ## Ownership
 


### PR DESCRIPTION
## Add `none` option for `systemModel`

### Context

In the Backstage [descriptor format](https://backstage.io/docs/features/software-catalog/descriptor-format), `spec.system` on a Component is **optional**. Today the
kubernetes-ingestor always assigns a system (and auto-creates the corresponding `System` entity) based on `systemModel` (`namespace` / `cluster` / `cluster-namespace` / `default`).

In some setups we simply don't want a default system attached to ingested components — only an explicit one when the resource asks for it.

### Change

Adds a new `systemModel: none` option:

- **No `terasky.backstage.io/system` annotation** → the component is ingested **without** `spec.system`, and **no `System` entity is auto-created**.
- **Explicit `terasky.backstage.io/system` annotation** → that value is used as `spec.system`; still no `System` entity is auto-created (it's assumed managed elsewhere).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a `systemModel: 'none'` mapping option: System entities are no longer auto-created and entity specs omit system relationships unless the resource explicitly sets the system annotation. This behavior applies across Kubernetes workloads, Crossplane, and KRO-derived entities.

* **Documentation**
  * Backend docs updated to show `systemModel: 'none'` and per-mapping placement.

* **Tests**
  * Added tests validating `systemModel: 'none'` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->