### PR TITLE
Add git brach prefix to Pull/Merge requests

### DIFF
--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -334,6 +334,12 @@ export interface Config {
              * @visibility frontend
              */
             targetBranch?: string;
+            /**
+             * Optional prefix for the pull request branch name (e.g. "feature/" or "cluster/")
+             * @default ''
+             * @visibility frontend
+             */
+            branchPrefix?: string;
           };
         };
         /**
@@ -449,6 +455,12 @@ export interface Config {
              * @visibility frontend
              */
             targetBranch?: string;
+            /**
+             * Optional prefix for the pull request branch name (e.g. "feature/" or "cluster/")
+             * @default ''
+             * @visibility frontend
+             */
+            branchPrefix?: string;
           };
         };
         /**
@@ -539,6 +551,12 @@ export interface Config {
            * @visibility frontend
            */
           targetBranch?: string;
+          /**
+           * Optional prefix for the pull request branch name (e.g. "feature/" or "cluster/")
+           * @default ''
+           * @visibility frontend
+           */
+          branchPrefix?: string;
         };
       };
     };

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3044,6 +3044,217 @@ describe('XRDTemplateEntityProvider', () => {
     });
   });
 
+  // ── branchPrefix ──────────────────────────────────────────────────────────────
+
+  describe('extractSteps – branchPrefix in publishPhase.git', () => {
+    const makeVersion = () => ({
+      name: 'v1alpha1',
+      schema: {
+        openAPIV3Schema: {
+          type: 'object',
+          properties: { spec: { type: 'object', properties: {} } },
+        },
+      },
+    });
+
+    const makeXrd = (annotations: Record<string, string> = {}) => ({
+      metadata: { name: 'myresources.example.com', annotations },
+      spec: {
+        scope: 'Cluster',
+        names: { kind: 'MyResource' },
+        group: 'example.com',
+        versions: [makeVersion()],
+      },
+      clusters: ['test-cluster'],
+      clusterName: 'test-cluster',
+    });
+
+    it('prepends branchPrefix to branchName when allowRepoSelection is false', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: false,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                  branchPrefix: 'feature/',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const steps: any[] = (provider as any).extractSteps(makeVersion(), makeXrd());
+      const publishStep = steps.find((s: any) => s.input?.branchName);
+      expect(publishStep).toBeDefined();
+      expect(publishStep.input.branchName).toBe('feature/create-${{ parameters.xrName }}-resource');
+    });
+
+    it('uses Jinja2 parameters.branchPrefix in branchName when allowRepoSelection is true', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: true,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                  branchPrefix: 'cluster/',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const steps: any[] = (provider as any).extractSteps(makeVersion(), makeXrd());
+      const publishStep = steps.find((s: any) => s.input?.branchName);
+      expect(publishStep).toBeDefined();
+      expect(publishStep.input.branchName).toBe('${{ parameters.branchPrefix }}create-${{ parameters.xrName }}-resource');
+    });
+
+    it('includes branchPrefix field with default in extractParameters when allowRepoSelection is true', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: true,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                  branchPrefix: 'feature',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const params: any = (provider as any).extractParameters(makeVersion(), makeXrd());
+      const creationStep = params.find((p: any) => p.properties?.branchPrefix);
+      expect(creationStep).toBeDefined();
+      expect(creationStep.properties.branchPrefix.default).toBe('feature/');
+    });
+
+    it('auto-appends trailing slash when branchPrefix has none', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: false,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                  branchPrefix: 'feature',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const steps: any[] = (provider as any).extractSteps(makeVersion(), makeXrd());
+      const publishStep = steps.find((s: any) => s.input?.branchName);
+      expect(publishStep).toBeDefined();
+      expect(publishStep.input.branchName).toBe('feature/create-${{ parameters.xrName }}-resource');
+    });
+
+    it('does not double-add slash when branchPrefix already ends with /', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: false,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                  branchPrefix: 'feature/',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const steps: any[] = (provider as any).extractSteps(makeVersion(), makeXrd());
+      const publishStep = steps.find((s: any) => s.input?.branchName);
+      expect(publishStep).toBeDefined();
+      expect(publishStep.input.branchName).toBe('feature/create-${{ parameters.xrName }}-resource');
+    });
+
+    it('uses default branchName without prefix when branchPrefix is not set', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          annotationPrefix: 'terasky.backstage.io',
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'github',
+                allowRepoSelection: false,
+                git: {
+                  repoUrl: 'github.com?owner=test&repo=manifests',
+                  targetBranch: 'main',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const steps: any[] = (provider as any).extractSteps(makeVersion(), makeXrd());
+      const publishStep = steps.find((s: any) => s.input?.branchName);
+      expect(publishStep).toBeDefined();
+      expect(publishStep.input.branchName).toBe('create-${{ parameters.xrName }}-resource');
+    });
+  });
+
   // ── target-path: hide manifestLayout / clusters ──────────────────────────────
 
   describe('extractParameters – target-path hides manifestLayout and clusters', () => {

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -1294,6 +1294,13 @@ export class XRDTemplateEntityProvider implements EntityProvider {
                     description: 'Target Branch for the PR',
                     default: 'main',
                   },
+                  branchPrefix: {
+                    type: 'string',
+                    description: 'Prefix for the PR branch name (e.g. "feature/"). Include the trailing slash.',
+                    default: XRDTemplateEntityProvider.normalizeBranchPrefix(
+                      this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.branchPrefix') ?? '',
+                    ),
+                  },
                   ...(!hasTargetPath && {
                     manifestLayout: {
                       type: 'string',
@@ -1426,7 +1433,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         `    nameParam: xrName\n${ 
         isNamespaced ? '    namespaceParam: xrNamespace\n' : '    namespaceParam: ""\n' 
         }    ownerParam: owner\n` +
-        `    excludeParams: ['crossplane.compositionSelectionStrategy','owner','pushToGit','basePath','manifestLayout','_editData','targetBranch','repoUrl','clusters','xrName','showAdvancedSettings'${  isNamespaced ? ', \'xrNamespace\'' : ''  }]\n` +
+        `    excludeParams: ['crossplane.compositionSelectionStrategy','owner','pushToGit','basePath','manifestLayout','_editData','targetBranch','repoUrl','clusters','xrName','showAdvancedSettings','branchPrefix'${  isNamespaced ? ', \'xrNamespace\'' : ''  }]\n` +
         `    apiVersion: {API_VERSION}\n` +
         `    kind: {KIND}\n${ 
         clustersLine 
@@ -1444,7 +1451,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         `    nameParam: xrName\n` +
         `    namespaceParam: xrNamespace\n` +
         `    ownerParam: owner\n` +
-        `    excludeParams: ['owner', 'compositionSelectionStrategy','pushToGit','basePath','manifestLayout','_editData', 'targetBranch', 'repoUrl', 'clusters', 'xrName', 'xrNamespace', 'showAdvancedSettings']\n` +
+        `    excludeParams: ['owner', 'compositionSelectionStrategy','pushToGit','basePath','manifestLayout','_editData', 'targetBranch', 'repoUrl', 'clusters', 'xrName', 'xrNamespace', 'showAdvancedSettings', 'branchPrefix']\n` +
         `    apiVersion: {API_VERSION}\n` +
         `    kind: {KIND}\n${ 
         clustersLine 
@@ -1472,6 +1479,9 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     }
     const allowRepoSelection = this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.publishPhase.allowRepoSelection') ?? false;
     const requestUserCredentials = this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.publishPhase.requestUserCredentialsForRepoUrl') ?? false;
+    const branchPrefix = XRDTemplateEntityProvider.normalizeBranchPrefix(
+      this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.branchPrefix') ?? '',
+    );
     const userOAuthTokenInput = requestUserCredentials
       ? '    token: ${{ secrets.USER_OAUTH_TOKEN }}\n'
       : '';
@@ -1482,7 +1492,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       `  if: \${{ parameters.pushToGit }}\n` +
       `  input:\n` +
       `    repoUrl: \${{ parameters.repoUrl }}\n` +
-      `    branchName: create-\${{ parameters.xrName }}-resource\n` +
+      `    branchName: \${{ parameters.branchPrefix }}create-\${{ parameters.xrName }}-resource\n` +
       `    title: Create {KIND} Resource \${{ parameters.xrName }}\n` +
       `    description: Create {KIND} Resource \${{ parameters.xrName }}\n` +
       `    targetBranchName: \${{ parameters.targetBranch }}\n${ 
@@ -1502,7 +1512,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
           `  if: \${{ parameters.pushToGit }}\n` +
           `  input:\n` +
           `    repoUrl: ${this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.repoUrl')}\n` +
-          `    branchName: create-\${{ parameters.xrName }}-resource\n` +
+          `    branchName: ${branchPrefix}create-\${{ parameters.xrName }}-resource\n` +
           `    title: Create {KIND} Resource \${{ parameters.xrName }}\n` +
           `    description: Create {KIND} Resource \${{ parameters.xrName }}\n` +
           `    targetBranchName: ${this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.targetBranch')}\n${ 
@@ -1544,6 +1554,10 @@ export class XRDTemplateEntityProvider implements EntityProvider {
 
     // Combine default steps with any additional steps
     return [...defaultSteps, ...additionalSteps];
+  }
+
+  private static normalizeBranchPrefix(raw: string): string {
+    return raw && !raw.endsWith('/') ? `${raw}/` : raw;
   }
 
   // Returns true when the template is non-empty and contains no traversal segments ('.' or '..').
@@ -2145,6 +2159,13 @@ export class XRDTemplateEntityProvider implements EntityProvider {
                     description: "Target Branch for the PR",
                     default: "main"
                   },
+                  branchPrefix: {
+                    type: "string",
+                    description: 'Prefix for the PR branch name (e.g. "feature/"). Include the trailing slash.',
+                    default: XRDTemplateEntityProvider.normalizeBranchPrefix(
+                      this.config.getOptionalString('kubernetesIngestor.genericCRDTemplates.publishPhase.git.branchPrefix') ?? '',
+                    ),
+                  },
                   manifestLayout: {
                     type: "string",
                     description: "Layout of the manifest",
@@ -2293,7 +2314,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       `    parameters: \${{ parameters }}\n` +
       `    nameParam: name\n${ 
       crd.spec.scope === 'Namespaced' ? '    namespaceParam: namespace\n' : '    namespaceParam: ""\n' 
-      }    excludeParams: ['compositionSelectionStrategy','pushToGit','basePath','manifestLayout','_editData', 'targetBranch', 'repoUrl', 'clusters', 'name', 'namespace', 'owner']\n` +
+      }    excludeParams: ['compositionSelectionStrategy','pushToGit','basePath','manifestLayout','_editData', 'targetBranch', 'repoUrl', 'clusters', 'name', 'namespace', 'owner', 'branchPrefix']\n` +
       `    apiVersion: ${crd.spec.group}/${version.name}\n` +
       `    kind: ${crd.spec.names.kind}\n` +
       `    clusters: \${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}\n` +
@@ -2318,6 +2339,9 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     }
     const allowRepoSelection = this.config.getOptionalBoolean('kubernetesIngestor.genericCRDTemplates.publishPhase.allowRepoSelection') ?? false;
     const requestUserCredentials = this.config.getOptionalBoolean('kubernetesIngestor.genericCRDTemplates.publishPhase.requestUserCredentialsForRepoUrl') ?? false;
+    const branchPrefix = XRDTemplateEntityProvider.normalizeBranchPrefix(
+      this.config.getOptionalString('kubernetesIngestor.genericCRDTemplates.publishPhase.git.branchPrefix') ?? '',
+    );
     const userOAuthTokenInput = requestUserCredentials
       ? '    token: ${{ secrets.USER_OAUTH_TOKEN }}\n'
       : '';
@@ -2333,7 +2357,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
           `  if: \${{ parameters.pushToGit }}\n` +
           `  input:\n` +
           `    repoUrl: \${{ parameters.repoUrl }}\n` +
-          `    branchName: create-\${{ parameters.name }}-resource\n` +
+          `    branchName: \${{ parameters.branchPrefix }}create-\${{ parameters.name }}-resource\n` +
           `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
           `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
           `    targetBranchName: \${{ parameters.targetBranch }}\n${ 
@@ -2346,7 +2370,7 @@ export class XRDTemplateEntityProvider implements EntityProvider {
           `  if: \${{ parameters.pushToGit }}\n` +
           `  input:\n` +
           `    repoUrl: ${this.config.getOptionalString('kubernetesIngestor.genericCRDTemplates.publishPhase.git.repoUrl')}\n` +
-          `    branchName: create-\${{ parameters.name }}-resource\n` +
+          `    branchName: ${branchPrefix}create-\${{ parameters.name }}-resource\n` +
           `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
           `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
           `    targetBranchName: ${this.config.getOptionalString('kubernetesIngestor.genericCRDTemplates.publishPhase.git.targetBranch')}\n${ 

--- a/plugins/kubernetes-ingestor/src/providers/RGDTemplateEntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/RGDTemplateEntityProvider.test.ts
@@ -1,0 +1,153 @@
+import { RGDTemplateEntityProvider } from './RGDTemplateEntityProvider';
+import { ConfigReader } from '@backstage/config';
+
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+beforeEach(() => {
+  console.log = jest.fn();
+  console.error = jest.fn();
+  console.warn = jest.fn();
+});
+afterEach(() => {
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+});
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+const makeCrd = () => ({
+  metadata: { name: 'myrgds.example.com' },
+  spec: {
+    names: { kind: 'MyRGD', plural: 'myrgds' },
+    group: 'example.com',
+    scope: 'Namespaced',
+    versions: [{ name: 'v1alpha1', schema: { openAPIV3Schema: { type: 'object', properties: { spec: { type: 'object', properties: {} } } } } }],
+  },
+});
+
+const makeRgd = () => ({
+  metadata: { name: 'myrgds.example.com' },
+  spec: {},
+});
+
+function makeProvider(publishPhaseOverrides: Record<string, any> = {}) {
+  const config = new ConfigReader({
+    kubernetesIngestor: {
+      kro: {
+        rgds: {
+          publishPhase: {
+            target: 'github',
+            allowRepoSelection: false,
+            git: {
+              repoUrl: 'github.com?owner=test&repo=manifests',
+              targetBranch: 'main',
+              ...publishPhaseOverrides,
+            },
+          },
+        },
+      },
+    },
+  });
+  return new RGDTemplateEntityProvider(
+    { run: jest.fn() } as any,
+    mockLogger as any,
+    config,
+    { getResource: jest.fn().mockResolvedValue(null) } as any,
+  );
+}
+
+// ── branchPrefix – allowRepoSelection: false ──────────────────────────────────
+
+describe('RGDTemplateEntityProvider – branchPrefix (allowRepoSelection: false)', () => {
+  it('uses kroInstanceName (not name) in branchName', () => {
+    const provider = makeProvider();
+    const steps: any[] = (provider as any).extractSteps(makeCrd(), makeRgd());
+    const publishStep = steps.find((s: any) => s.input?.branchName);
+    expect(publishStep).toBeDefined();
+    expect(publishStep.input.branchName).toContain('kroInstanceName');
+    expect(publishStep.input.branchName).not.toContain('parameters.name}}');
+  });
+
+  it('prepends branchPrefix when set without trailing slash', () => {
+    const provider = makeProvider({ branchPrefix: 'feature' });
+    const steps: any[] = (provider as any).extractSteps(makeCrd(), makeRgd());
+    const publishStep = steps.find((s: any) => s.input?.branchName);
+    expect(publishStep.input.branchName).toBe('feature/create-${{ parameters.kroInstanceName }}-resource');
+  });
+
+  it('does not double-add slash when branchPrefix already ends with /', () => {
+    const provider = makeProvider({ branchPrefix: 'feature/' });
+    const steps: any[] = (provider as any).extractSteps(makeCrd(), makeRgd());
+    const publishStep = steps.find((s: any) => s.input?.branchName);
+    expect(publishStep.input.branchName).toBe('feature/create-${{ parameters.kroInstanceName }}-resource');
+  });
+
+  it('uses default branchName without prefix when branchPrefix is not set', () => {
+    const provider = makeProvider();
+    const steps: any[] = (provider as any).extractSteps(makeCrd(), makeRgd());
+    const publishStep = steps.find((s: any) => s.input?.branchName);
+    expect(publishStep.input.branchName).toBe('create-${{ parameters.kroInstanceName }}-resource');
+  });
+});
+
+// ── branchPrefix – allowRepoSelection: true ───────────────────────────────────
+
+describe('RGDTemplateEntityProvider – branchPrefix (allowRepoSelection: true)', () => {
+  function makeProviderWithRepoSelection(branchPrefix?: string) {
+    const config = new ConfigReader({
+      kubernetesIngestor: {
+        kro: {
+          rgds: {
+            publishPhase: {
+              target: 'github',
+              allowRepoSelection: true,
+              git: {
+                repoUrl: 'github.com?owner=test&repo=manifests',
+                targetBranch: 'main',
+                ...(branchPrefix !== undefined ? { branchPrefix } : {}),
+              },
+            },
+          },
+        },
+      },
+    });
+    return new RGDTemplateEntityProvider(
+      { run: jest.fn() } as any,
+      mockLogger as any,
+      config,
+      { getResource: jest.fn().mockResolvedValue(null) } as any,
+    );
+  }
+
+  it('uses Jinja2 parameters.branchPrefix in branchName', () => {
+    const provider = makeProviderWithRepoSelection('feature/');
+    const steps: any[] = (provider as any).extractSteps(makeCrd(), makeRgd());
+    const publishStep = steps.find((s: any) => s.input?.branchName);
+    expect(publishStep).toBeDefined();
+    expect(publishStep.input.branchName).toBe('${{ parameters.branchPrefix }}create-${{ parameters.kroInstanceName }}-resource');
+  });
+
+  it('includes branchPrefix field with normalized default in extractParameters', () => {
+    const provider = makeProviderWithRepoSelection('feature');
+    const params: any[] = (provider as any).extractParameters(makeCrd(), [], makeRgd());
+    const publishStep = params.find((p: any) => p.properties?.branchPrefix);
+    expect(publishStep).toBeDefined();
+    expect(publishStep.properties.branchPrefix.default).toBe('feature/');
+  });
+
+  it('branchPrefix default is empty string when not configured', () => {
+    const provider = makeProviderWithRepoSelection();
+    const params: any[] = (provider as any).extractParameters(makeCrd(), [], makeRgd());
+    const publishStep = params.find((p: any) => p.properties?.branchPrefix);
+    expect(publishStep).toBeDefined();
+    expect(publishStep.properties.branchPrefix.default).toBe('');
+  });
+});

--- a/plugins/kubernetes-ingestor/src/providers/RGDTemplateEntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/RGDTemplateEntityProvider.ts
@@ -600,6 +600,13 @@ export class RGDTemplateEntityProvider implements EntityProvider {
                     description: 'Target Branch for the PR',
                     default: 'main',
                   },
+                  branchPrefix: {
+                    type: 'string',
+                    description: 'Prefix for the PR branch name (e.g. "feature/"). Include the trailing slash.',
+                    default: RGDTemplateEntityProvider.normalizeBranchPrefix(
+                      this.config.getOptionalString('kubernetesIngestor.kro.rgds.publishPhase.git.branchPrefix') ?? '',
+                    ),
+                  },
                   manifestLayout: {
                     type: 'string',
                     description: 'Layout of the manifest',
@@ -750,7 +757,7 @@ export class RGDTemplateEntityProvider implements EntityProvider {
       '    parameters: ${{ parameters }}\n' +
       '    nameParam: kroInstanceName\n' +
       '    namespaceParam: kroInstanceNamespace\n' +
-      '    excludeParams: [\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\', \'targetBranch\', \'repoUrl\', \'clusters\', \'kroInstanceName\', \'kroInstanceNamespace\', \'owner\']\n' +
+      '    excludeParams: [\'pushToGit\',\'basePath\',\'manifestLayout\',\'_editData\', \'targetBranch\', \'repoUrl\', \'clusters\', \'kroInstanceName\', \'kroInstanceNamespace\', \'owner\', \'branchPrefix\']\n' +
       `    apiVersion: ${crd.spec.group}/${crd.spec.versions[0].name}\n` +
       `    kind: ${crd.spec.names.kind}\n` +
       '    clusters: ${{ parameters.clusters if parameters.manifestLayout === \'cluster-scoped\' and parameters.pushToGit else [\'temp\'] }}\n' +
@@ -770,7 +777,7 @@ export class RGDTemplateEntityProvider implements EntityProvider {
       '  input:\n' +
       '    files:\n' +
       '      - from: ${{ steps.generateManifest.output.filePaths[0] }}\n' +
-      '        to: "./${{ parameters.basePath }}/${{ parameters.name }}.yaml"\n';
+      '        to: "./${{ parameters.basePath }}/${{ parameters.kroInstanceName }}.yaml"\n';
 
     const publishPhaseTarget = this.config.getOptionalString('kubernetesIngestor.kro.rgds.publishPhase.target')?.toLowerCase();
     let action = '';
@@ -791,6 +798,9 @@ export class RGDTemplateEntityProvider implements EntityProvider {
     }
     const allowRepoSelection = this.config.getOptionalBoolean('kubernetesIngestor.kro.rgds.publishPhase.allowRepoSelection') ?? false;
     const requestUserCredentials = this.config.getOptionalBoolean('kubernetesIngestor.kro.rgds.publishPhase.requestUserCredentialsForRepoUrl') ?? false;
+    const branchPrefix = RGDTemplateEntityProvider.normalizeBranchPrefix(
+      this.config.getOptionalString('kubernetesIngestor.kro.rgds.publishPhase.git.branchPrefix') ?? '',
+    );
     const userOAuthTokenInput = requestUserCredentials
       ? '    token: ${{ secrets.USER_OAUTH_TOKEN }}\n'
       : '';
@@ -806,9 +816,9 @@ export class RGDTemplateEntityProvider implements EntityProvider {
           `  if: \${{ parameters.pushToGit }}\n` +
           `  input:\n` +
           `    repoUrl: \${{ parameters.repoUrl }}\n` +
-          `    branchName: create-\${{ parameters.name }}-resource\n` +
-          `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
-          `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
+          `    branchName: \${{ parameters.branchPrefix }}create-\${{ parameters.kroInstanceName }}-resource\n` +
+          `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.kroInstanceName }}\n` +
+          `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.kroInstanceName }}\n` +
           `    targetBranchName: \${{ parameters.targetBranch }}\n${ 
           userOAuthTokenInput}`;
       } else {
@@ -819,15 +829,19 @@ export class RGDTemplateEntityProvider implements EntityProvider {
           `  if: \${{ parameters.pushToGit }}\n` +
           `  input:\n` +
           `    repoUrl: ${this.config.getOptionalString('kubernetesIngestor.kro.rgds.publishPhase.git.repoUrl')}\n` +
-          `    branchName: create-\${{ parameters.name }}-resource\n` +
-          `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
-          `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.name }}\n` +
+          `    branchName: ${branchPrefix}create-\${{ parameters.kroInstanceName }}-resource\n` +
+          `    title: Create ${crd.spec.names.kind} Resource \${{ parameters.kroInstanceName }}\n` +
+          `    description: Create ${crd.spec.names.kind} Resource \${{ parameters.kroInstanceName }}\n` +
           `    targetBranchName: ${this.config.getOptionalString('kubernetesIngestor.kro.rgds.publishPhase.git.targetBranch')}\n${ 
           userOAuthTokenInput}`;
       }
     }
 
     return yaml.load(defaultStepsYaml) as any[];
+  }
+
+  private static normalizeBranchPrefix(raw: string): string {
+    return raw && !raw.endsWith('/') ? `${raw}/` : raw;
   }
 
   private getPullRequestUrl(): string {

--- a/site/docs/plugins/kubernetes-ingestor/backend/configure.md
+++ b/site/docs/plugins/kubernetes-ingestor/backend/configure.md
@@ -99,6 +99,8 @@ kubernetesIngestor:
           # Follows the backstage standard format which is github.com?owner=<REPO OWNER>&repo=<REPO NAME>
           repoUrl:
           targetBranch: main
+          # Optional prefix prepended to the PR branch name (e.g. "feature/" → feature/create-my-resource)
+          branchPrefix: ""
         # Whether the user should be able to select the repo they want to push the manifest to or not
         allowRepoSelection: true
         # Whether to request user OAuth credentials when selecting a repository URL (defaults to false)
@@ -127,6 +129,8 @@ kubernetesIngestor:
         # Follows the backstage static format which is github.com?owner=<REPO OWNER>&repo=<REPO NAME>
         repoUrl:
         targetBranch: main
+        # Optional prefix prepended to the PR branch name (e.g. "feature/" → feature/create-my-resource)
+        branchPrefix: ""
       # Whether the user should be able to select the repo they want to push the manifest to or not
       allowRepoSelection: true
       # Whether to request user OAuth credentials when selecting a repository URL (defaults to false)
@@ -155,6 +159,8 @@ kubernetesIngestor:
           # Follows the backstage standard format which is github.com?owner=<REPO OWNER>&repo=<REPO NAME>
           repoUrl:
           targetBranch: main
+          # Optional prefix prepended to the PR branch name (e.g. "feature/" → feature/create-my-resource)
+          branchPrefix: ""
         # Whether the user should be able to select the repo they want to push the manifest to or not
         allowRepoSelection: true
         # Whether to request user OAuth credentials when selecting a repository URL (defaults to false)
@@ -964,6 +970,8 @@ xrds:
     git:
       repoUrl: github.com?owner=org&repo=templates
       targetBranch: main
+      # Optional: prefix for the PR branch name. E.g. "feature/" → feature/create-my-resource
+      branchPrefix: ""
   
   # Processing settings
   convertDefaultValuesToPlaceholders: true
@@ -997,6 +1005,8 @@ kro:
       git:
         repoUrl: github.com?owner=org&repo=templates
         targetBranch: main
+        # Optional: prefix for the PR branch name. E.g. "cluster/" → cluster/create-my-resource
+        branchPrefix: ""
     
     # Processing settings
     enabled: true


### PR DESCRIPTION
Add branchPrefix support to publishPhase configuration

Adds an optional branchPrefix field to publishPhase.git config for XRD, CRD, and RGD template providers.

Config example:

publishPhase:
  git:
    repoUrl: github.com?owner=Playtika&repo=cloud-orchestration
    targetBranch: development
    branchPrefix: feature/
Behavior:

allowRepoSelection: false — prefix is applied at template-generation time from config; trailing slash is added automatically (feature → feature/)
allowRepoSelection: true — prefix is exposed as an editable form field with the config value as default; user can override it per-submission

Result: feature/create-some-service-resource instead of create-some-service-resource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `branchPrefix` support for Git pull request branch naming across XRD, RGD, and generic CRD template publishing.
  * `branchPrefix` is exposed in “Creation Settings” (when repo selection is enabled) and normalized to ensure consistent trailing-slash behavior.
* **Bug Fixes**
  * Fixed custom manifest generation output to use the Kubernetes instance name for the YAML path.
* **Documentation**
  * Updated Kubernetes Ingestor backend configuration examples to include `branchPrefix`.
* **Tests**
  * Added coverage for `branchPrefix` behavior with and without repo selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->