### PR TITLE
feat(kubernetes-ingestor): support Azure DevOps claim pull requests

### DIFF
--- a/plugins/kubernetes-ingestor/config.d.ts
+++ b/plugins/kubernetes-ingestor/config.d.ts
@@ -301,7 +301,9 @@ export interface Config {
          */
         publishPhase?: {
           /**
-           * Target system for publishing (github, gitlab, catalog)
+           * Target system for publishing (github, gitlab, bitbucket, azure, yaml).
+           * Azure requires @backstage-community/plugin-scaffolder-backend-module-azure-devops
+           * and @terasky/backstage-plugin-scaffolder-backend-module-terasky-utils.
            * @visibility frontend
            */
           target?: string;

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3354,15 +3354,18 @@ describe('XRDTemplateEntityProvider', () => {
 
       const steps: any[] = (provider as any).extractSteps(version, xrd);
 
-      expect(steps.map(step => step.action)).toEqual(expect.arrayContaining([
+      expect(steps.map(step => step.action)).toEqual([
         'terasky:azure-devops:repository-details',
+        'azure:repository:clone',
+        'terasky:claim-template',
         'azure:repository:push',
         'azure:pr:create',
-      ]));
+      ]);
+      expect(steps.find(step => step.id === 'clone-repository').input.branch).toBe('main');
       expect(steps.find(step => step.id === 'create-pull-request').input.targetBranch).toBe('main');
     });
 
-    it('injects targetPath onto the Azure push step', () => {
+    it('writes the manifest to the annotated path instead of setting targetPath', () => {
       const provider = new XRDTemplateEntityProvider(
         { run: jest.fn() } as any,
         mockLogger,
@@ -3383,10 +3386,14 @@ describe('XRDTemplateEntityProvider', () => {
       };
 
       const steps: any[] = (provider as any).extractSteps(version, xrd);
-      const pushStep = steps.find((s: any) => s.action === 'azure:repository:push');
-      expect(pushStep.input.targetPath).toBe(
-        'presets/${{ parameters.dc | lower }}/${{ parameters.xrName | lower }}',
-      );
+      const manifestStep = steps.find((s: any) => s.action === 'terasky:claim-template');
+      expect(manifestStep.input.xrdPathTemplate).toBe('presets/{dc}/{xrName}');
+      expect(manifestStep.input.xrdPathInWorkspace).toBe(true);
+
+      // azure:repository:push accepts only sourcePath, so targetPath must not be emitted.
+      for (const step of steps) {
+        expect(step.input?.targetPath).toBeUndefined();
+      }
     });
 
     it('allows RepoUrlPicker to select dev.azure.com when allowedTargets is unset', () => {

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3361,6 +3361,86 @@ describe('XRDTemplateEntityProvider', () => {
       ]));
       expect(steps.find(step => step.id === 'create-pull-request').input.targetBranch).toBe('main');
     });
+
+    it('injects targetPath onto the Azure push step', () => {
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        azureConfig,
+        mockResourceFetcher as any,
+      );
+      const version = {
+        name: 'v1alpha1',
+        schema: { openAPIV3Schema: { type: 'object', properties: { spec: { type: 'object', properties: {} } } } },
+      };
+      const xrd = {
+        metadata: {
+          name: 'myresources.example.com',
+          annotations: { 'terasky.backstage.io/target-path': 'presets/{dc}/{xrName}' },
+        },
+        spec: { scope: 'Cluster', names: { kind: 'MyResource' }, group: 'example.com', versions: [version] },
+        clusters: ['test-cluster'],
+      };
+
+      const steps: any[] = (provider as any).extractSteps(version, xrd);
+      const pushStep = steps.find((s: any) => s.action === 'azure:repository:push');
+      expect(pushStep.input.targetPath).toBe(
+        'presets/${{ parameters.dc | lower }}/${{ parameters.xrName | lower }}',
+      );
+    });
+
+    it('allows RepoUrlPicker to select dev.azure.com when allowedTargets is unset', () => {
+      const config = new ConfigReader({
+        kubernetesIngestor: {
+          crossplane: {
+            xrds: {
+              publishPhase: {
+                target: 'azure',
+                allowRepoSelection: true,
+                git: {
+                  repoUrl: 'dev.azure.com?organization=example&project=Platform&repo=manifests',
+                  targetBranch: 'main',
+                },
+              },
+            },
+          },
+        },
+      });
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        config,
+        mockResourceFetcher as any,
+      );
+      const version = {
+        name: 'v1alpha1',
+        schema: { openAPIV3Schema: { type: 'object', properties: { spec: { type: 'object', properties: {} } } } },
+      };
+      const xrd = {
+        metadata: { name: 'myresources.example.com', annotations: {} },
+        spec: { scope: 'Cluster', names: { kind: 'MyResource' }, group: 'example.com', versions: [version] },
+        clusters: ['test-cluster'],
+      };
+
+      const params: any[] = (provider as any).extractParameters(version, ['test-cluster'], xrd);
+      const creationStep = params.find((p: any) =>
+        JSON.stringify(p).includes('RepoUrlPicker'),
+      );
+      expect(JSON.stringify(creationStep)).toContain('dev.azure.com');
+    });
+
+    it('builds an Azure DevOps pull request URL from remoteUrl and pullRequestId', () => {
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        azureConfig,
+        mockResourceFetcher as any,
+      );
+
+      expect((provider as any).getPullRequestUrl()).toBe(
+        '${{ steps["azure-repository-details"].output.remoteUrl }}/pullrequest/${{ steps["create-pull-request"].output.pullRequestId }}',
+      );
+    });
   });
 
   // ── branchPrefix ──────────────────────────────────────────────────────────────

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.test.ts
@@ -3317,6 +3317,52 @@ describe('XRDTemplateEntityProvider', () => {
     });
   });
 
+  describe('extractSteps – Azure DevOps publishing', () => {
+    const azureConfig = new ConfigReader({
+      kubernetesIngestor: {
+        crossplane: {
+          xrds: {
+            publishPhase: {
+              target: 'azure',
+              allowRepoSelection: false,
+              git: {
+                repoUrl: 'dev.azure.com?organization=example&project=Platform&repo=manifests',
+                targetBranch: 'main',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    it('pushes a branch and creates an Azure DevOps pull request', () => {
+      const provider = new XRDTemplateEntityProvider(
+        { run: jest.fn() } as any,
+        mockLogger,
+        azureConfig,
+        mockResourceFetcher as any,
+      );
+      const version = {
+        name: 'v1alpha1',
+        schema: { openAPIV3Schema: { type: 'object', properties: { spec: { type: 'object', properties: {} } } } },
+      };
+      const xrd = {
+        metadata: { name: 'myresources.example.com', annotations: {} },
+        spec: { scope: 'Cluster', names: { kind: 'MyResource' }, group: 'example.com', versions: [version] },
+        clusters: ['test-cluster'],
+      };
+
+      const steps: any[] = (provider as any).extractSteps(version, xrd);
+
+      expect(steps.map(step => step.action)).toEqual(expect.arrayContaining([
+        'terasky:azure-devops:repository-details',
+        'azure:repository:push',
+        'azure:pr:create',
+      ]));
+      expect(steps.find(step => step.id === 'create-pull-request').input.targetBranch).toBe('main');
+    });
+  });
+
   // ── branchPrefix ──────────────────────────────────────────────────────────────
 
   describe('extractSteps – branchPrefix in publishPhase.git', () => {

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -1438,13 +1438,19 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       ? rawXrdPathTemplate
       : undefined;
 
+    const publishPhaseTarget = this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.target')?.toLowerCase();
+    const isAzureTarget = publishPhaseTarget === 'azure' || publishPhaseTarget === 'azuredevops';
+
     // When target-path annotation is set the clusters selector is hidden from the form →
     // use a static value so the action receives a valid non-empty array.
     const clustersLine = safeXrdPathTemplate
       ? "    clusters: ['temp']\n"
       : "    clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}\n";
+    // azure:repository:push commits a cloned working copy and takes no targetPath, so the
+    // resolved path has to be applied when the manifest is written rather than on publish.
     const xrdPathLines =
       (safeXrdPathTemplate ? `    xrdPathTemplate: '${safeXrdPathTemplate.replace(/'/g, "''")}'\n` : '') +
+      (safeXrdPathTemplate && isAzureTarget ? '    xrdPathInWorkspace: true\n' : '') +
       (generateKustomization ? '    generateKustomization: true\n' : '');
 
     let baseStepsYaml = '';
@@ -1487,7 +1493,6 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         }${xrdPathLines}`;
     }
 
-    const publishPhaseTarget = this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.target')?.toLowerCase();
     let action = '';
     switch (publishPhaseTarget) {
       case 'azure':
@@ -1525,13 +1530,23 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     const azureTargetBranch = allowRepoSelection
       ? '${{ parameters.targetBranch }}'
       : this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.targetBranch');
-    const azurePublishStepsYaml =
+    // azure:repository:push stages and commits an existing working copy, so the repository
+    // has to be cloned into the workspace before the manifest is generated into it.
+    const azureCloneStepsYaml =
       `- id: azure-repository-details\n` +
       `  name: Parse Azure DevOps repository\n` +
       `  action: terasky:azure-devops:repository-details\n` +
       `  if: \${{ parameters.pushToGit }}\n` +
       `  input:\n` +
       `    repoUrl: ${azureRepoUrl}\n` +
+      `- id: clone-repository\n` +
+      `  name: Clone target repository\n` +
+      `  action: azure:repository:clone\n` +
+      `  if: \${{ parameters.pushToGit }}\n` +
+      `  input:\n` +
+      `    remoteUrl: \${{ steps['azure-repository-details'].output.remoteUrl }}\n` +
+      `    branch: ${azureTargetBranch}\n${userOAuthTokenInput}`;
+    const azurePublishStepsYaml =
       `- id: push-branch\n` +
       `  name: Push manifest branch\n` +
       `  action: azure:repository:push\n` +
@@ -1568,8 +1583,8 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     let defaultStepsYaml = baseStepsYaml;
 
     if (publishPhaseTarget !== 'yaml') {
-      if (publishPhaseTarget === 'azure' || publishPhaseTarget === 'azuredevops') {
-        defaultStepsYaml += azurePublishStepsYaml;
+      if (isAzureTarget) {
+        defaultStepsYaml = azureCloneStepsYaml + baseStepsYaml + azurePublishStepsYaml;
       } else if (allowRepoSelection) {
         defaultStepsYaml += repoSelectionStepsYaml;
       }
@@ -1605,15 +1620,14 @@ export class XRDTemplateEntityProvider implements EntityProvider {
 
     // Inject targetPath into publish step when target-path annotation is set on XRD.
     // {param} variables are converted to Jinja2 expressions resolved by the scaffolder engine.
-    if (safeXrdPathTemplate) {
+    // Azure DevOps is excluded: its push action has no targetPath, so the path is applied
+    // when the manifest is written (xrdPathInWorkspace above).
+    if (safeXrdPathTemplate && !isAzureTarget) {
       const resolvedTargetPath = XRDTemplateEntityProvider.resolvePathTemplateToJinja2(safeXrdPathTemplate);
       for (const step of defaultSteps) {
         if (
           step?.input &&
-          ('targetBranchName' in step.input ||
-            'branchName' in step.input ||
-            'branch' in step.input ||
-            'sourceBranch' in step.input)
+          ('targetBranchName' in step.input || 'branchName' in step.input)
         ) {
           step.input.targetPath = resolvedTargetPath;
           break;

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -1229,6 +1229,10 @@ export class XRDTemplateEntityProvider implements EntityProvider {
         case 'bitbucketcloud':
           allowedHosts = ['bitbucket.org'];
           break;
+        case 'azure':
+        case 'azuredevops':
+          allowedHosts = ['dev.azure.com'];
+          break;
         default:
           allowedHosts = [];
       }
@@ -1604,7 +1608,13 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     if (safeXrdPathTemplate) {
       const resolvedTargetPath = XRDTemplateEntityProvider.resolvePathTemplateToJinja2(safeXrdPathTemplate);
       for (const step of defaultSteps) {
-        if (step?.input && ('targetBranchName' in step.input || 'branchName' in step.input)) {
+        if (
+          step?.input &&
+          ('targetBranchName' in step.input ||
+            'branchName' in step.input ||
+            'branch' in step.input ||
+            'sourceBranch' in step.input)
+        ) {
           step.input.targetPath = resolvedTargetPath;
           break;
         }
@@ -1647,6 +1657,9 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       case 'bitbucket':
       case 'bitbucketcloud':
         return '${{ steps["create-pull-request"].output.pullRequestUrl }}';
+      case 'azure':
+      case 'azuredevops':
+        return '${{ steps["azure-repository-details"].output.remoteUrl }}/pullrequest/${{ steps["create-pull-request"].output.pullRequestId }}';
       case 'github':
       default:
         return '${{ steps["create-pull-request"].output.remoteUrl }}';

--- a/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/EntityProvider.ts
@@ -1486,6 +1486,10 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     const publishPhaseTarget = this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.target')?.toLowerCase();
     let action = '';
     switch (publishPhaseTarget) {
+      case 'azure':
+      case 'azuredevops':
+        action = 'azure:repository:push';
+        break;
       case 'gitlab':
         action = 'publish:gitlab:merge-request';
         break;
@@ -1508,6 +1512,42 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     const userOAuthTokenInput = requestUserCredentials
       ? '    token: ${{ secrets.USER_OAUTH_TOKEN }}\n'
       : '';
+    const azureRepoUrl = allowRepoSelection
+      ? '${{ parameters.repoUrl }}'
+      : this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.repoUrl');
+    const azureBranchName = allowRepoSelection
+      ? '${{ parameters.branchPrefix }}create-${{ parameters.xrName }}-resource'
+      : `${branchPrefix}create-\${{ parameters.xrName }}-resource`;
+    const azureTargetBranch = allowRepoSelection
+      ? '${{ parameters.targetBranch }}'
+      : this.config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.targetBranch');
+    const azurePublishStepsYaml =
+      `- id: azure-repository-details\n` +
+      `  name: Parse Azure DevOps repository\n` +
+      `  action: terasky:azure-devops:repository-details\n` +
+      `  if: \${{ parameters.pushToGit }}\n` +
+      `  input:\n` +
+      `    repoUrl: ${azureRepoUrl}\n` +
+      `- id: push-branch\n` +
+      `  name: Push manifest branch\n` +
+      `  action: azure:repository:push\n` +
+      `  if: \${{ parameters.pushToGit }}\n` +
+      `  input:\n` +
+      `    remoteUrl: \${{ steps['azure-repository-details'].output.remoteUrl }}\n` +
+      `    branch: ${azureBranchName}\n` +
+      `    gitCommitMessage: Create {KIND} Resource \${{ parameters.xrName }}\n${userOAuthTokenInput}` +
+      `- id: create-pull-request\n` +
+      `  name: Create pull request\n` +
+      `  action: azure:pr:create\n` +
+      `  if: \${{ parameters.pushToGit }}\n` +
+      `  input:\n` +
+      `    organization: \${{ steps['azure-repository-details'].output.organization }}\n` +
+      `    project: \${{ steps['azure-repository-details'].output.project }}\n` +
+      `    repoName: \${{ steps['azure-repository-details'].output.repository }}\n` +
+      `    sourceBranch: ${azureBranchName}\n` +
+      `    targetBranch: ${azureTargetBranch}\n` +
+      `    title: Create {KIND} Resource \${{ parameters.xrName }}\n` +
+      `    description: Create {KIND} Resource \${{ parameters.xrName }}\n${userOAuthTokenInput}`;
     const repoSelectionStepsYaml =
       `- id: create-pull-request\n` +
       `  name: create-pull-request\n` +
@@ -1524,7 +1564,9 @@ export class XRDTemplateEntityProvider implements EntityProvider {
     let defaultStepsYaml = baseStepsYaml;
 
     if (publishPhaseTarget !== 'yaml') {
-      if (allowRepoSelection) {
+      if (publishPhaseTarget === 'azure' || publishPhaseTarget === 'azuredevops') {
+        defaultStepsYaml += azurePublishStepsYaml;
+      } else if (allowRepoSelection) {
         defaultStepsYaml += repoSelectionStepsYaml;
       }
       else {

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.test.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.test.ts
@@ -34,4 +34,10 @@ describe('createAzureDevOpsRepositoryDetailsAction', () => {
       action.handler!({ input: { repoUrl: 'github.com?owner=example&repo=gitops' }, output } as any),
     ).rejects.toThrow('repoUrl must be an Azure DevOps RepoUrlPicker value');
   });
+
+  it('rejects an unparseable repoUrl with the same format message', async () => {
+    await expect(
+      action.handler!({ input: { repoUrl: 'not a url' }, output } as any),
+    ).rejects.toThrow('repoUrl must be an Azure DevOps RepoUrlPicker value');
+  });
 });

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.test.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.test.ts
@@ -1,0 +1,37 @@
+import { createAzureDevOpsRepositoryDetailsAction } from './azure-devops-repository';
+
+describe('createAzureDevOpsRepositoryDetailsAction', () => {
+  const action = createAzureDevOpsRepositoryDetailsAction();
+  const output = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has the expected action id', () => {
+    expect(action.id).toBe('terasky:azure-devops:repository-details');
+  });
+
+  it('parses a RepoUrlPicker Azure DevOps URL', async () => {
+    await action.handler!({
+      input: {
+        repoUrl: 'dev.azure.com?organization=example&project=Platform%20Engineering&repo=gitops',
+      },
+      output,
+    } as any);
+
+    expect(output).toHaveBeenCalledWith('organization', 'example');
+    expect(output).toHaveBeenCalledWith('project', 'Platform Engineering');
+    expect(output).toHaveBeenCalledWith('repository', 'gitops');
+    expect(output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://dev.azure.com/example/Platform%20Engineering/_git/gitops',
+    );
+  });
+
+  it('rejects an incomplete or non-Azure DevOps URL', async () => {
+    await expect(
+      action.handler!({ input: { repoUrl: 'github.com?owner=example&repo=gitops' }, output } as any),
+    ).rejects.toThrow('repoUrl must be an Azure DevOps RepoUrlPicker value');
+  });
+});

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.ts
@@ -24,20 +24,28 @@ export function createAzureDevOpsRepositoryDetailsAction() {
       },
     },
     async handler(ctx) {
-      const url = new URL(
-        ctx.input.repoUrl.includes('://')
-          ? ctx.input.repoUrl
-          : `https://${ctx.input.repoUrl}`,
+      const invalidRepoUrlError = new Error(
+        'repoUrl must be an Azure DevOps RepoUrlPicker value: ' +
+        'dev.azure.com?organization=<organization>&project=<project>&repo=<repository>',
       );
+
+      let url: URL;
+      try {
+        url = new URL(
+          ctx.input.repoUrl.includes('://')
+            ? ctx.input.repoUrl
+            : `https://${ctx.input.repoUrl}`,
+        );
+      } catch {
+        throw invalidRepoUrlError;
+      }
+
       const organization = url.searchParams.get('organization');
       const project = url.searchParams.get('project');
       const repository = url.searchParams.get('repo');
 
       if (url.hostname !== 'dev.azure.com' || !organization || !project || !repository) {
-        throw new Error(
-          'repoUrl must be an Azure DevOps RepoUrlPicker value: ' +
-          'dev.azure.com?organization=<organization>&project=<project>&repo=<repository>',
-        );
+        throw invalidRepoUrlError;
       }
 
       ctx.output('organization', organization);

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/azure-devops-repository.ts
@@ -1,0 +1,52 @@
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+
+/**
+ * Parses the RepoUrlPicker Azure DevOps form value used by Backstage:
+ * dev.azure.com?organization=<org>&project=<project>&repo=<repo>.
+ *
+ * The Azure DevOps scaffolder actions need those values separately, while the
+ * Kubernetes ingestor must support both its configured repository and a
+ * repository selected by the user at template execution time.
+ */
+export function createAzureDevOpsRepositoryDetailsAction() {
+  return createTemplateAction({
+    id: 'terasky:azure-devops:repository-details',
+    description: 'Parse an Azure DevOps repository URL for scaffolder actions',
+    schema: {
+      input: {
+        repoUrl: z => z.string().describe('Azure DevOps repository URL from RepoUrlPicker'),
+      },
+      output: {
+        organization: z => z.string().describe('Azure DevOps organization'),
+        project: z => z.string().describe('Azure DevOps project'),
+        repository: z => z.string().describe('Azure DevOps repository name'),
+        remoteUrl: z => z.string().describe('HTTPS Git URL for the repository'),
+      },
+    },
+    async handler(ctx) {
+      const url = new URL(
+        ctx.input.repoUrl.includes('://')
+          ? ctx.input.repoUrl
+          : `https://${ctx.input.repoUrl}`,
+      );
+      const organization = url.searchParams.get('organization');
+      const project = url.searchParams.get('project');
+      const repository = url.searchParams.get('repo');
+
+      if (url.hostname !== 'dev.azure.com' || !organization || !project || !repository) {
+        throw new Error(
+          'repoUrl must be an Azure DevOps RepoUrlPicker value: ' +
+          'dev.azure.com?organization=<organization>&project=<project>&repo=<repository>',
+        );
+      }
+
+      ctx.output('organization', organization);
+      ctx.output('project', project);
+      ctx.output('repository', repository);
+      ctx.output(
+        'remoteUrl',
+        `https://dev.azure.com/${encodeURIComponent(organization)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repository)}`,
+      );
+    },
+  });
+}

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
@@ -772,6 +772,38 @@ describe('createCrossplaneClaimAction', () => {
       expect(fetchUrl).toContain('presets/eu-west-1/my-db/kustomization.yaml');
     });
 
+    it('merges into a cloned kustomization.yaml already in the workspace', async () => {
+      // Azure DevOps clones the repo into the workspace before templating, and the
+      // remote lookup below only speaks the GitHub contents API.
+      mockHttpsGet(404);
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) =>
+        p === '/tmp/workspace/presets/eu-west-1/my-db/kustomization.yaml',
+      );
+      (fs.readFileSync as jest.Mock).mockReturnValue(`---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - already-in-repo.yaml
+`);
+
+      const action = createCrossplaneClaimAction({ config: mockConfig });
+      const ctx = createMockContext({
+        ...baseInput,
+        generateKustomization: true,
+        xrdPathInWorkspace: true,
+      });
+
+      await action.handler!(ctx as any);
+
+      const calls = (fs.outputFileSync as jest.Mock).mock.calls;
+      const [, kustomizationContent] = calls.find(([p]: [string]) =>
+        p.endsWith('kustomization.yaml'),
+      );
+      expect(kustomizationContent).toContain('already-in-repo.yaml');
+      expect(kustomizationContent).toContain('my-db.yaml');
+      expect(httpsModule.get as jest.Mock).not.toHaveBeenCalled();
+    });
+
     it('merges new entry into existing kustomization.yaml fetched from GitHub', async () => {
       const existingKustomization = `---
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.test.ts
@@ -535,6 +535,30 @@ describe('createCrossplaneClaimAction', () => {
       expect(writtenPath).toBe('/tmp/workspace/my-db.yaml');
     });
 
+    it('resolves xrdPathTemplate into the workspace path when xrdPathInWorkspace is set', async () => {
+      const action = createCrossplaneClaimAction({ config: mockConfig });
+      const ctx = createMockContext({
+        parameters: { xrName: 'my-db', dc: 'eu-west-1', owner: 'group:default/team' },
+        nameParam: 'xrName',
+        namespaceParam: 'xrNamespace',
+        excludeParams: ['xrName', 'xrNamespace'],
+        apiVersion: 'test.io/v1alpha1',
+        kind: 'Database',
+        clusters: ['temp'],
+        removeEmptyParams: true,
+        ownerParam: 'owner',
+        xrdPathTemplate: 'presets/{dc}/{xrName}',
+        xrdPathInWorkspace: true,
+      });
+
+      await action.handler!(ctx as any);
+
+      const [[writtenPath]] = (fs.outputFileSync as jest.Mock).mock.calls;
+      // azure:repository:push commits a cloned working copy and has no targetPath,
+      // so the repo path has to exist on disk.
+      expect(writtenPath).toBe('/tmp/workspace/presets/eu-west-1/my-db/my-db.yaml');
+    });
+
     it('does NOT double the path when xrdPathTemplate matches the annotation value', async () => {
       const action = createCrossplaneClaimAction({ config: mockConfig });
       const ctx = createMockContext({

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
@@ -318,8 +318,27 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
             : path.relative(ctx.workspacePath, kustomizationDir);
 
           let existingResources: string[] = [];
+
+          // A publish flow that clones the repository into the workspace first (Azure DevOps)
+          // already has the current kustomization.yaml on disk. Merge into that, otherwise the
+          // remote lookup below — which only speaks the GitHub contents API — silently drops
+          // every resource already listed in the file.
           try {
-            if (owner && repo) {
+            if (fs.existsSync(kustomizationPath)) {
+              const parsed = yaml.load(fs.readFileSync(kustomizationPath, 'utf8') as string) as any;
+              if (Array.isArray(parsed?.resources)) {
+                existingResources = parsed.resources;
+                ctx.logger.info(
+                  `Merging into kustomization.yaml already in the workspace at ${kustomizationDir} with ${existingResources.length} resource(s)`,
+                );
+              }
+            }
+          } catch (e) {
+            ctx.logger.warn(`Could not read kustomization.yaml at ${kustomizationPath}: ${e}`);
+          }
+
+          try {
+            if (existingResources.length === 0 && owner && repo) {
               const kustomizationGitPath = encodeURI(resolvedRepoDir ? `${resolvedRepoDir}/kustomization.yaml` : 'kustomization.yaml');
               const fetchUrl = `${apiBase}/repos/${owner}/${repo}/contents/${kustomizationGitPath}?ref=${targetBranch}`;
 

--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
@@ -89,6 +89,7 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
         ownerParam: z => z.string().describe('Template parameter to map to the owner of the claim'),
         specFieldOrder: z => z.array(z.string()).describe('Ordered list of spec field names (derived from x-ui-order) to control key order in the generated manifest').optional(),
         xrdPathTemplate: z => z.string().optional().describe('Path template from terasky.backstage.io/target-path XRD annotation, e.g. presets/{dc}/{xrName}. Overrides manifestLayout/basePath.'),
+        xrdPathInWorkspace: z => z.boolean().optional().describe('When true, resolve xrdPathTemplate into the workspace path instead of writing to the workspace root. Required for publish actions that commit a cloned working copy and have no targetPath input, such as azure:repository:push.'),
         generateKustomization: z => z.boolean().optional().describe('When true, generates or updates kustomization.yaml in the target path (from terasky.backstage.io/create-kustomization-file XRD annotation)'),
       },
       output: {
@@ -174,9 +175,13 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
       // publish step controls the final location in the repo without path doubling.
       // e.g. annotation "clusters/{dc}/{xrName}" → targetPath="clusters/eu/my-app" in PR,
       //      file on disk → workspacePath/my-app.yaml (not workspacePath/clusters/eu/my-app/my-app.yaml)
+      // Publish actions that commit a cloned working copy have no targetPath, so under
+      // xrdPathInWorkspace the resolved path is applied on disk instead.
       if (input.xrdPathTemplate) {
         sourceInfo.gitLayout = 'custom';
-        sourceInfo.basePath = '';
+        sourceInfo.basePath = input.xrdPathInWorkspace
+          ? resolvePathTemplate(input.xrdPathTemplate, input.parameters as Record<string, any>)
+          : '';
       }
 
       // Write the manifest to the file system for each cluster

--- a/plugins/scaffolder-backend-module-terasky-utils/src/module.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/module.ts
@@ -3,6 +3,7 @@ import { scaffolderActionsExtensionPoint  } from '@backstage/plugin-scaffolder-n
 import { createCrossplaneClaimAction } from "./actions/claim-templating";
 import { createCatalogInfoCleanerAction } from "./actions/catalog-info-cleaner";
 import { createCrdTemplateAction } from "./actions/crd-templating";
+import { createAzureDevOpsRepositoryDetailsAction } from "./actions/azure-devops-repository";
 /**
  * A backend module that registers the action into the scaffolder
  */
@@ -19,6 +20,7 @@ export const scaffolderModule = createBackendModule({
         scaffolderActions.addActions(createCrossplaneClaimAction({config: config}));
         scaffolderActions.addActions(createCatalogInfoCleanerAction());
         scaffolderActions.addActions(createCrdTemplateAction({config: config}));
+        scaffolderActions.addActions(createAzureDevOpsRepositoryDetailsAction());
       }
     });
   },


### PR DESCRIPTION
## Summary
- add an Azure DevOps target for Crossplane XRD-generated scaffolder templates
- parse the `RepoUrlPicker` Azure DevOps URL at template runtime
- push the generated manifest to a new branch with `azure:repository:push`, then create a PR with `azure:pr:create`
- document the two required backend modules and cover the generated flow with unit tests

## Problem
`publishPhase.target: azure` was not handled by the Kubernetes ingestor. It fell through to `publish:github:pull-request`, which cannot publish to a `dev.azure.com` repository.

## Notes
The generated flow intentionally opens a pull request; it does not write directly to the default branch. The target requires the host app to register `@backstage-community/plugin-scaffolder-backend-module-azure-devops` for the `azure:repository:push` and `azure:pr:create` actions, plus the TeraSky utilities module added here.

## Test plan
- [x] Added unit coverage for Azure RepoUrlPicker parsing.
- [x] Added unit coverage that an Azure XRD template generates parse, push, and PR actions.
- [ ] `yarn install --immutable` could not complete locally because the repository's existing `isolated-vm` native dependency failed to build on the local Node 26 runtime; tests could not be executed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure DevOps publishing support for Crossplane XRD templates.
  * Generated workflows can retrieve repository details, push branches, and create pull requests.
  * Added configurable source and target branches, repository paths, and workspace-based template locations.
  * Added validation and repository URL details for Azure DevOps scaffolder inputs.
  * Preserved existing workspace resources during template publishing.

* **Documentation**
  * Updated publishing configuration documentation to include Bitbucket, Azure, and YAML targets.
  * Documented required Azure and Terasky utility packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->