### PR TITLE
fix(scaffolder): clone nested parameters  Backstage freezes task input

### DIFF
--- a/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
+++ b/plugins/scaffolder-backend-module-terasky-utils/src/actions/claim-templating.ts
@@ -111,7 +111,7 @@ export function createCrossplaneClaimAction({config}: {config: any}) {
       }
 
       // Remove excluded parameters (always exclude showAdvancedSettings regardless of excludeParams list)
-      const filteredParameters = { ...input.parameters };
+      const filteredParameters = structuredClone(input.parameters);
       // Helper to delete nested keys using dot notation
       function deleteNested(obj: any, keyPath: string) {
         const parts = keyPath.split('.');


### PR DESCRIPTION
I got this error while trying to create a resource from a generated template:

TypeError: Cannot delete property 'compositionSelectionStrategy' of [object Object]
 at deleteNested (..\node_modules\@terasky\backstage-plugin-scaffolder-backend-module-terasky-utils\src\actions\claim-templating.ts:122:24)
 at <anonymous> (..\node_modules\@terasky\backstage-plugin-scaffolder-backend-module-terasky-utils\src\actions\claim-templating.ts:138:11)
 at Set.forEach (<anonymous>)\n at Object.handler (..\node_modules\@terasky\backstage-plugin-scaffolder-backend-module-terasky-utils\src\actions\claim-templating.ts:136:18)
 at NunjucksWorkflowRunner.executeStep (..\node_modules\@backstage\plugin-scaffolder-backend\src\scaffolder\tasks\NunjucksWorkflowRunner.ts:616:22)
 at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
 at async NunjucksWorkflowRunner.execute (..\node_modules\@backstage\plugin-scaffolder-backend\src\scaffolder\tasks\NunjucksWorkflowRunner.ts:829:29)
 at async TaskWorker.runOneTask (..\node_modules\@backstage\plugin-scaffolder-backend\src\scaffolder\tasks\TaskWorker.ts:227:26)\n
 at async run (..\node_modules\p-queue\dist\index.js:163:29 

And this patch makes sure that the input parmaters are copied because some field were immutable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter processing to preserve nested input data during templating.
  * Prevented cleanup and exclusions from unintentionally modifying the original input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->